### PR TITLE
Add parser coverage audit workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Prepare cached dataset artifacts from LeanDojo:
 python scripts/prepare_dataset.py --sample-per-split 100 --output-root artifacts/prepared/v1 --force
 ```
 
+Audit parser coverage on real LeanDojo states without generating training artifacts:
+
+```bash
+python scripts/audit_parser.py --sample-per-split 100 --output-root artifacts/audits/parser/v1 --force
+```
+
 Train the baseline GraphSAGE classifier from a prepared cache:
 
 ```bash

--- a/atp_lean_gnn/__init__.py
+++ b/atp_lean_gnn/__init__.py
@@ -1,3 +1,4 @@
+from .audit import DEFAULT_AUDIT_OUTPUT_ROOT, ParserAuditConfig, run_parser_audit
 from .analysis import analyze_saved_run, compare_saved_runs, load_metrics_history, load_run_summary, render_run_comparison_markdown
 from .cache import SplitReport, build_failure_record, build_json_payload
 from .cli import DEMO_STATE
@@ -5,7 +6,8 @@ from .dataset import DatasetRow, iter_dataset_rows
 from .graph import DAGBuilder, GraphNode, GraphStats, dag_to_dict, graph_stats, proof_state_to_dag, write_dag_json
 from .labels import EMPTY_TACTIC, UNKNOWN_TACTIC, build_tactic_vocab, encode_tactic_name, label_example, normalize_tactic
 from .model import GraphSAGEClassifierConfig, GraphSAGEStateClassifier
-from .preprocess import DEFAULT_OUTPUT_ROOT, PreprocessConfig, prepare_example, run_preprocessing
+from .preparation import PreparedExample, prepare_example
+from .preprocess import DEFAULT_OUTPUT_ROOT, PreprocessConfig, run_preprocessing
 from .pyg import NODE_TYPE_TO_ID, build_vocab, build_vocab_from_labels, dag_to_pyg
 from .state import Hypothesis, ProofState, parse_state
 from .training import (
@@ -28,6 +30,7 @@ __all__ = [
     "BaselineConfig",
     "DAGBuilder",
     "DEMO_STATE",
+    "DEFAULT_AUDIT_OUTPUT_ROOT",
     "DEFAULT_BASELINE_CONFIG_PATH",
     "DEFAULT_OUTPUT_ROOT",
     "DatasetRow",
@@ -40,7 +43,9 @@ __all__ = [
     "NODE_TYPE_TO_ID",
     "PreparedGraphDataset",
     "PreparedMetadata",
+    "PreparedExample",
     "ProofState",
+    "ParserAuditConfig",
     "PreprocessConfig",
     "TrainingLoopConfig",
     "analyze_saved_run",
@@ -70,6 +75,7 @@ __all__ = [
     "prepare_example",
     "proof_state_to_dag",
     "render_run_comparison_markdown",
+    "run_parser_audit",
     "run_preprocessing",
     "SplitReport",
     "train_baseline",

--- a/atp_lean_gnn/audit.py
+++ b/atp_lean_gnn/audit.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import argparse
+import statistics
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+from .cache import (
+    SplitReport,
+    append_failure_record,
+    build_failure_record,
+    prepare_audit_output_root,
+    write_manifest,
+    write_parser_audit_json,
+    write_parser_audit_markdown,
+)
+from .dataset import DATASET_NAME, canonicalize_split_name, iter_dataset_rows
+from .preparation import prepare_example
+from .reporting import console_print
+
+
+DEFAULT_AUDIT_OUTPUT_ROOT = Path("artifacts") / "audits" / "parser" / "v1"
+
+
+@dataclass(frozen=True)
+class ParserAuditConfig:
+    dataset_name: str = DATASET_NAME
+    splits: tuple[str, ...] = ("train", "val", "test")
+    output_root: Path = DEFAULT_AUDIT_OUTPUT_ROOT
+    sample_per_split: int | None = None
+    max_examples_per_category: int = 5
+    force: bool = False
+
+
+def _normalize_splits(raw_splits: str | list[str] | tuple[str, ...]) -> list[str]:
+    if isinstance(raw_splits, str):
+        candidates = [part.strip() for part in raw_splits.split(",")]
+    else:
+        candidates = [part.strip() for part in raw_splits]
+
+    splits: list[str] = []
+    for split in candidates:
+        if not split:
+            continue
+        canonical_split = canonicalize_split_name(split)
+        if canonical_split not in splits:
+            splits.append(canonical_split)
+
+    if not splits:
+        raise ValueError("At least one split must be provided.")
+    return splits
+
+
+def _counter_summary(counter: Counter[str], *, limit: int = 10) -> list[dict[str, object]]:
+    return [{"name": name, "count": count} for (name, count) in counter.most_common(limit)]
+
+
+def _merge_representative_examples(
+    split_reports: dict[str, SplitReport],
+    *,
+    max_examples_per_category: int,
+    top_categories: list[str],
+) -> dict[str, list[dict[str, object]]]:
+    representative_examples: dict[str, list[dict[str, object]]] = {}
+    for category in top_categories:
+        examples: list[dict[str, object]] = []
+        for split in split_reports:
+            for example in split_reports[split].representative_failures.get(category, []):
+                if len(examples) >= max_examples_per_category:
+                    break
+                examples.append(example)
+            if len(examples) >= max_examples_per_category:
+                break
+        representative_examples[category] = examples
+    return representative_examples
+
+
+def _safe_mean(values: list[int]) -> float:
+    if not values:
+        return 0.0
+    return float(statistics.mean(values))
+
+
+def _safe_median(values: list[int]) -> float:
+    if not values:
+        return 0.0
+    return float(statistics.median(values))
+
+
+def _build_parser_audit_summary(
+    *,
+    config: ParserAuditConfig,
+    manifests: dict[str, dict[str, object]],
+    split_reports: dict[str, SplitReport],
+) -> dict[str, object]:
+    overall_attempted = sum(report.attempted_count for report in split_reports.values())
+    overall_success = sum(report.success_count for report in split_reports.values())
+    overall_failure = sum(report.failure_count for report in split_reports.values())
+
+    overall_failure_categories: Counter[str] = Counter()
+    overall_failure_phases: Counter[str] = Counter()
+    all_node_counts: list[int] = []
+    all_edge_counts: list[int] = []
+    all_reused_counts: list[int] = []
+
+    for report in split_reports.values():
+        overall_failure_categories.update(report.failure_categories)
+        overall_failure_phases.update(report.failure_phases)
+        all_node_counts.extend(report.node_counts)
+        all_edge_counts.extend(report.edge_counts)
+        all_reused_counts.extend(report.reused_node_counts)
+
+    top_failure_categories = _counter_summary(overall_failure_categories)
+    top_failure_phases = _counter_summary(overall_failure_phases)
+    recommended_follow_up_categories = _counter_summary(overall_failure_categories, limit=5)
+    representative_examples = _merge_representative_examples(
+        split_reports,
+        max_examples_per_category=config.max_examples_per_category,
+        top_categories=[item["name"] for item in recommended_follow_up_categories],
+    )
+
+    return {
+        "dataset": config.dataset_name,
+        "output_root": str(Path(config.output_root)),
+        "splits": list(config.splits),
+        "sample_per_split": config.sample_per_split,
+        "max_examples_per_category": config.max_examples_per_category,
+        "overall": {
+            "attempted_count": overall_attempted,
+            "success_count": overall_success,
+            "failure_count": overall_failure,
+            "parser_success_rate": 0.0 if overall_attempted == 0 else overall_success / overall_attempted,
+        },
+        "overall_graph_stats": {
+            "node_count": {
+                "mean": _safe_mean(all_node_counts),
+                "median": _safe_median(all_node_counts),
+            },
+            "edge_count": {
+                "mean": _safe_mean(all_edge_counts),
+                "median": _safe_median(all_edge_counts),
+            },
+            "reused_node_count": {
+                "mean": _safe_mean(all_reused_counts),
+                "median": _safe_median(all_reused_counts),
+            },
+        },
+        "splits_summary": manifests,
+        "top_failure_categories": top_failure_categories,
+        "top_failure_phases": top_failure_phases,
+        "representative_examples": representative_examples,
+        "recommended_follow_up_categories": recommended_follow_up_categories,
+    }
+
+
+def _render_parser_audit_markdown(summary: dict[str, object]) -> str:
+    lines = [
+        "# Parser Coverage Audit",
+        "",
+        f"- dataset: `{summary['dataset']}`",
+        f"- output root: `{summary['output_root']}`",
+        f"- processed splits: `{', '.join(summary['splits'])}`",
+        f"- sample per split: `{summary['sample_per_split']}`",
+        f"- max examples per category: `{summary['max_examples_per_category']}`",
+        f"- attempted examples: `{summary['overall']['attempted_count']}`",
+        f"- successful examples: `{summary['overall']['success_count']}`",
+        f"- failed examples: `{summary['overall']['failure_count']}`",
+        f"- parser success rate: `{summary['overall']['parser_success_rate']:.3f}`",
+        "",
+        "## Split Metrics",
+        "",
+        "| Split | Attempted | Success | Failure | Success Rate | Mean Nodes | Median Nodes | Mean Edges | Median Edges |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+
+    for split in summary["splits"]:
+        split_summary = summary["splits_summary"][split]
+        lines.append(
+            "| "
+            f"{split} | "
+            f"{split_summary['attempted_count']} | "
+            f"{split_summary['success_count']} | "
+            f"{split_summary['failure_count']} | "
+            f"{split_summary['parser_success_rate']:.3f} | "
+            f"{split_summary['graph_stats']['node_count']['mean']:.2f} | "
+            f"{split_summary['graph_stats']['node_count']['median']:.2f} | "
+            f"{split_summary['graph_stats']['edge_count']['mean']:.2f} | "
+            f"{split_summary['graph_stats']['edge_count']['median']:.2f} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Top Failure Categories",
+            "",
+            "| Category | Count |",
+            "| --- | ---: |",
+        ]
+    )
+    if summary["top_failure_categories"]:
+        for item in summary["top_failure_categories"]:
+            lines.append(f"| `{item['name']}` | {item['count']} |")
+    else:
+        lines.append("| `none` | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "## Top Failure Phases",
+            "",
+            "| Phase | Count |",
+            "| --- | ---: |",
+        ]
+    )
+    if summary["top_failure_phases"]:
+        for item in summary["top_failure_phases"]:
+            lines.append(f"| `{item['name']}` | {item['count']} |")
+    else:
+        lines.append("| `none` | 0 |")
+
+    lines.extend(["", "## Recommended Follow-Up Categories", ""])
+    if summary["recommended_follow_up_categories"]:
+        for item in summary["recommended_follow_up_categories"]:
+            lines.append(f"- `{item['name']}`: {item['count']}")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Representative Examples", ""])
+    if summary["representative_examples"]:
+        for category, examples in summary["representative_examples"].items():
+            lines.append(f"### `{category}`")
+            if not examples:
+                lines.append("")
+                lines.append("- no saved examples")
+                lines.append("")
+                continue
+            lines.append("")
+            for example in examples:
+                lines.append(
+                    "- "
+                    f"split=`{example['split']}` "
+                    f"row=`{example['row_index']}` "
+                    f"theorem=`{example['theorem'] or '<unknown>'}` "
+                    f"error=`{example['error_message']}`"
+                )
+                state_preview = str(example.get("state_preview", "")).strip()
+                if state_preview:
+                    lines.append("")
+                    lines.append("```text")
+                    lines.append(state_preview)
+                    lines.append("```")
+            lines.append("")
+    else:
+        lines.append("- no representative failures recorded")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def run_parser_audit(config: ParserAuditConfig) -> dict[str, object]:
+    output_root = prepare_audit_output_root(
+        config.output_root,
+        splits=list(config.splits),
+        force=config.force,
+    )
+
+    split_reports: dict[str, SplitReport] = {}
+    manifests: dict[str, dict[str, object]] = {}
+
+    for split in config.splits:
+        console_print(f"\n  Auditing split '{split}'...")
+        report = SplitReport(split=split)
+
+        for row in iter_dataset_rows(
+            dataset_name=config.dataset_name,
+            split=split,
+            sample_limit=config.sample_per_split,
+        ):
+            try:
+                example = prepare_example(row)
+            except Exception as exc:
+                failure_record = build_failure_record(row, exc)
+                append_failure_record(output_root, split=split, record=failure_record)
+                report.record_failure(
+                    category=str(failure_record["failure_category"]),
+                    phase=str(failure_record["phase"]),
+                    example=failure_record,
+                    max_examples_per_category=config.max_examples_per_category,
+                )
+                continue
+
+            report.record_success(dag=example.dag, tactic_name=example.tactic_name)
+
+        manifest = report.to_audit_manifest(
+            dataset_name=config.dataset_name,
+            output_root=output_root,
+            sample_limit=config.sample_per_split,
+        )
+        write_manifest(output_root, split=split, manifest=manifest)
+        split_reports[split] = report
+        manifests[split] = manifest
+        console_print(
+            f"  Finished '{split}': attempted={report.attempted_count}, "
+            f"success={report.success_count}, failure={report.failure_count}"
+        )
+
+    summary = _build_parser_audit_summary(
+        config=config,
+        manifests=manifests,
+        split_reports=split_reports,
+    )
+    summary_json_path = write_parser_audit_json(output_root, summary)
+    summary_md_path = write_parser_audit_markdown(
+        output_root,
+        _render_parser_audit_markdown(summary),
+    )
+
+    console_print(f"\n  Wrote parser audit JSON    : {summary_json_path}")
+    console_print(f"  Wrote parser audit Markdown: {summary_md_path}")
+    return summary
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit parser coverage on LeanDojo proof states")
+    parser.add_argument("--dataset-name", type=str, default=DATASET_NAME, help="Dataset name to stream from Hugging Face")
+    parser.add_argument("--splits", type=str, default="train,val,test", help="Comma-separated splits to audit")
+    parser.add_argument("--output-root", type=str, default=str(DEFAULT_AUDIT_OUTPUT_ROOT), help="Output directory for parser audit reports")
+    parser.add_argument("--sample-per-split", type=int, default=None, help="Optional limit of examples to process per split")
+    parser.add_argument("--max-examples-per-category", type=int, default=5, help="Maximum representative failure examples to keep per category")
+    parser.add_argument("--force", action="store_true", help="Overwrite the output root if it already exists")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        config = ParserAuditConfig(
+            dataset_name=args.dataset_name,
+            splits=tuple(_normalize_splits(args.splits)),
+            output_root=Path(args.output_root),
+            sample_per_split=args.sample_per_split,
+            max_examples_per_category=args.max_examples_per_category,
+            force=args.force,
+        )
+        run_parser_audit(config)
+    except (FileExistsError, RuntimeError, ValueError) as exc:
+        console_print(f"  ERROR: {exc}")
+        return 1
+
+    return 0

--- a/atp_lean_gnn/cache.py
+++ b/atp_lean_gnn/cache.py
@@ -19,8 +19,7 @@ def example_stem(row_index: int) -> str:
     return f"{row_index:0{EXAMPLE_ID_WIDTH}d}"
 
 
-def prepare_output_root(output_root: str | Path, *, splits: list[str], force: bool) -> Path:
-    root = Path(output_root)
+def _reset_output_root(root: Path, *, force: bool) -> Path:
     if root.exists():
         if not force:
             raise FileExistsError(
@@ -30,12 +29,30 @@ def prepare_output_root(output_root: str | Path, *, splits: list[str], force: bo
             shutil.rmtree(root)
         else:
             root.unlink()
+    return root
+
+
+def prepare_output_root(output_root: str | Path, *, splits: list[str], force: bool) -> Path:
+    root = Path(output_root)
+    _reset_output_root(root, force=force)
 
     for split in splits:
         (root / split / "json").mkdir(parents=True, exist_ok=True)
         (root / split / "pyg").mkdir(parents=True, exist_ok=True)
 
     for dirname in ("failures", "manifests", "reports", "vocab"):
+        (root / dirname).mkdir(parents=True, exist_ok=True)
+    for split in splits:
+        (root / "failures" / f"{split}.jsonl").touch()
+
+    return root
+
+
+def prepare_audit_output_root(output_root: str | Path, *, splits: list[str], force: bool) -> Path:
+    root = Path(output_root)
+    _reset_output_root(root, force=force)
+
+    for dirname in ("failures", "manifests", "reports"):
         (root / dirname).mkdir(parents=True, exist_ok=True)
     for split in splits:
         (root / "failures" / f"{split}.jsonl").touch()
@@ -166,6 +183,20 @@ def write_summary_markdown(output_root: str | Path, summary: dict[str, object]) 
     return path
 
 
+def write_parser_audit_json(output_root: str | Path, summary: dict[str, object]) -> Path:
+    root = Path(output_root)
+    path = root / "reports" / "parser_audit.json"
+    return _write_json(path, summary)
+
+
+def write_parser_audit_markdown(output_root: str | Path, markdown: str) -> Path:
+    root = Path(output_root)
+    path = root / "reports" / "parser_audit.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(markdown, encoding="utf-8")
+    return path
+
+
 def build_json_payload(
     row: DatasetRow,
     *,
@@ -192,16 +223,31 @@ def build_json_payload(
     }
 
 
-def build_failure_record(row: DatasetRow, exc: Exception, *, phase: str) -> dict[str, object]:
+def _unwrap_failure(exc: Exception, phase: str | None) -> tuple[str, Exception]:
+    failure_phase = phase or getattr(exc, "phase", None) or "unknown"
+    failure_exc = getattr(exc, "cause", exc)
+    return failure_phase, failure_exc
+
+
+def build_failure_record(
+    row: DatasetRow,
+    exc: Exception,
+    *,
+    phase: str | None = None,
+) -> dict[str, object]:
+    failure_phase, failure_exc = _unwrap_failure(exc, phase)
+    error_type = failure_exc.__class__.__name__
+    failure_category = f"{failure_phase}:{error_type}"
     return {
         "dataset": row.dataset_name,
         "split": row.split,
         "row_index": row.row_index,
         "theorem": row.theorem,
         "tactic_raw": row.tactic,
-        "phase": phase,
-        "error_type": exc.__class__.__name__,
-        "error_message": str(exc),
+        "phase": failure_phase,
+        "failure_category": failure_category,
+        "error_type": error_type,
+        "error_message": str(failure_exc),
         "state_preview": "" if row.state is None else str(row.state)[:200],
     }
 
@@ -230,6 +276,8 @@ class SplitReport:
     reused_node_counts: list[int] = field(default_factory=list)
     tactic_counts: Counter[str] = field(default_factory=Counter)
     failure_categories: Counter[str] = field(default_factory=Counter)
+    failure_phases: Counter[str] = field(default_factory=Counter)
+    representative_failures: dict[str, list[dict[str, object]]] = field(default_factory=dict)
 
     def record_success(self, *, dag: DAGBuilder, tactic_name: str) -> None:
         self.attempted_count += 1
@@ -239,10 +287,24 @@ class SplitReport:
         self.reused_node_counts.append(len(dag.reused_nodes()))
         self.tactic_counts[tactic_name] += 1
 
-    def record_failure(self, *, category: str) -> None:
+    def record_failure(
+        self,
+        *,
+        category: str,
+        phase: str | None = None,
+        example: dict[str, object] | None = None,
+        max_examples_per_category: int | None = None,
+    ) -> None:
         self.attempted_count += 1
         self.failure_count += 1
         self.failure_categories[category] += 1
+        resolved_phase = phase or category.partition(":")[0] or "unknown"
+        self.failure_phases[resolved_phase] += 1
+
+        if example is not None and (max_examples_per_category is None or max_examples_per_category > 0):
+            bucket = self.representative_failures.setdefault(category, [])
+            if max_examples_per_category is None or len(bucket) < max_examples_per_category:
+                bucket.append(example)
 
     def parser_success_rate(self) -> float:
         if self.attempted_count == 0:
@@ -288,6 +350,42 @@ class SplitReport:
             "tactic_class_count": len(self.tactic_counts),
             "top_tactics": _counter_summary(self.tactic_counts),
             "top_failure_categories": _counter_summary(self.failure_categories),
+            "top_failure_phases": _counter_summary(self.failure_phases),
+        }
+
+    def to_audit_manifest(
+        self,
+        *,
+        dataset_name: str,
+        output_root: str | Path,
+        sample_limit: int | None,
+    ) -> dict[str, object]:
+        root = Path(output_root)
+        failure_log = root / "failures" / f"{self.split}.jsonl"
+        manifest_path = root / "manifests" / f"{self.split}.json"
+
+        return {
+            "dataset": dataset_name,
+            "split": self.split,
+            "sample_limit": sample_limit,
+            "attempted_count": self.attempted_count,
+            "success_count": self.success_count,
+            "failure_count": self.failure_count,
+            "parser_success_rate": self.parser_success_rate(),
+            "artifact_paths": {
+                "failure_log": _relative_to(failure_log, root),
+                "manifest": _relative_to(manifest_path, root),
+                "parser_audit_json": _relative_to(root / "reports" / "parser_audit.json", root),
+                "parser_audit_markdown": _relative_to(root / "reports" / "parser_audit.md", root),
+            },
+            "graph_stats": {
+                "node_count": _stats_dict(self.node_counts),
+                "edge_count": _stats_dict(self.edge_counts),
+                "reused_node_count": _stats_dict(self.reused_node_counts),
+            },
+            "top_failure_categories": _counter_summary(self.failure_categories),
+            "top_failure_phases": _counter_summary(self.failure_phases),
+            "representative_failure_examples": self.representative_failures,
         }
 
 

--- a/atp_lean_gnn/preparation.py
+++ b/atp_lean_gnn/preparation.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .dataset import DatasetRow
+from .graph import DAGBuilder, proof_state_to_dag
+from .labels import label_example
+from .state import ProofState, parse_state
+
+
+PREPARATION_PHASES = ("parse_state", "proof_state_to_dag", "label_example")
+
+
+@dataclass(frozen=True)
+class PreparedExample:
+    row: DatasetRow
+    parsed_state: ProofState
+    dag: DAGBuilder
+    tactic_name: str
+
+
+class PreparationPhaseError(Exception):
+    def __init__(self, *, phase: str, cause: Exception):
+        self.phase = phase
+        self.cause = cause
+        super().__init__(str(cause))
+
+
+def prepare_example(row: DatasetRow) -> PreparedExample:
+    try:
+        parsed_state = parse_state(row.state)
+    except Exception as exc:  # pragma: no cover - exercised via callers/tests
+        raise PreparationPhaseError(phase="parse_state", cause=exc) from exc
+
+    try:
+        dag = proof_state_to_dag(parsed_state)
+    except Exception as exc:  # pragma: no cover - exercised via callers/tests
+        raise PreparationPhaseError(phase="proof_state_to_dag", cause=exc) from exc
+
+    try:
+        label_info = label_example(row.tactic)
+    except Exception as exc:  # pragma: no cover - exercised via callers/tests
+        raise PreparationPhaseError(phase="label_example", cause=exc) from exc
+
+    return PreparedExample(
+        row=row,
+        parsed_state=parsed_state,
+        dag=dag,
+        tactic_name=str(label_info["tactic_name"]),
+    )

--- a/atp_lean_gnn/preprocess.py
+++ b/atp_lean_gnn/preprocess.py
@@ -18,23 +18,14 @@ from .cache import (
     write_summary_markdown,
     write_vocab,
 )
-from .dataset import DATASET_NAME, DatasetRow, canonicalize_split_name, iter_dataset_rows
-from .graph import proof_state_to_dag
-from .labels import build_tactic_vocab, encode_tactic_name, label_example
+from .dataset import DATASET_NAME, canonicalize_split_name, iter_dataset_rows
+from .preparation import prepare_example
+from .labels import build_tactic_vocab, encode_tactic_name
 from .pyg import build_vocab_from_labels, dag_to_pyg
 from .reporting import console_print
-from .state import ProofState, parse_state
 
 
 DEFAULT_OUTPUT_ROOT = Path("artifacts") / "prepared" / "v1"
-
-
-@dataclass(frozen=True)
-class PreparedExample:
-    row: DatasetRow
-    parsed_state: ProofState
-    dag: object
-    tactic_name: str
 
 
 @dataclass(frozen=True)
@@ -67,18 +58,6 @@ def _normalize_splits(raw_splits: str | list[str] | tuple[str, ...]) -> list[str
     return ["train", *[split for split in splits if split != "train"]]
 
 
-def prepare_example(row: DatasetRow) -> PreparedExample:
-    parsed_state = parse_state(row.state)
-    dag = proof_state_to_dag(parsed_state)
-    label_info = label_example(row.tactic)
-    return PreparedExample(
-        row=row,
-        parsed_state=parsed_state,
-        dag=dag,
-        tactic_name=str(label_info["tactic_name"]),
-    )
-
-
 def scan_train_split(
     *,
     dataset_name: str,
@@ -96,7 +75,11 @@ def scan_train_split(
         try:
             example = prepare_example(row)
         except Exception as exc:
-            report.record_failure(category=exc.__class__.__name__)
+            failure_record = build_failure_record(row, exc)
+            report.record_failure(
+                category=str(failure_record["failure_category"]),
+                phase=str(failure_record["phase"]),
+            )
             continue
 
         report.record_success(dag=example.dag, tactic_name=example.tactic_name)
@@ -131,9 +114,12 @@ def process_split(
         try:
             example = prepare_example(row)
         except Exception as exc:
-            failure_record = build_failure_record(row, exc, phase="prepare_example")
+            failure_record = build_failure_record(row, exc)
             append_failure_record(output_root, split=split, record=failure_record)
-            report.record_failure(category=failure_record["error_type"])
+            report.record_failure(
+                category=str(failure_record["failure_category"]),
+                phase=str(failure_record["phase"]),
+            )
             continue
 
         json_payload = build_json_payload(

--- a/scripts/audit_parser.py
+++ b/scripts/audit_parser.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+if __package__ in {None, ""}:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
+
+from atp_lean_gnn.audit import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dataset_preparation.py
+++ b/tests/test_dataset_preparation.py
@@ -105,6 +105,7 @@ class DatasetPreparationTests(unittest.TestCase):
         self.assertEqual(record["row_index"], 7)
         self.assertEqual(record["error_type"], "RuntimeError")
         self.assertEqual(record["phase"], "prepare_example")
+        self.assertEqual(record["failure_category"], "prepare_example:RuntimeError")
         self.assertIn("state_preview", record)
 
     def test_json_payload_shape(self) -> None:
@@ -174,6 +175,8 @@ class DatasetPreparationTests(unittest.TestCase):
         failure_record = json.loads(failure_log[0])
         self.assertEqual(failure_record["row_index"], 0)
         self.assertEqual(failure_record["error_type"], "TypeError")
+        self.assertEqual(failure_record["phase"], "parse_state")
+        self.assertEqual(failure_record["failure_category"], "parse_state:TypeError")
 
         train_json = json.loads((self.output_root / "train" / "json" / "000000001.json").read_text(encoding="utf-8"))
         self.assertEqual(train_json["metadata"]["tactic_name"], "simp")

--- a/tests/test_parser_audit.py
+++ b/tests/test_parser_audit.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import shutil
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from atp_lean_gnn import ParserAuditConfig, build_failure_record, run_parser_audit
+from atp_lean_gnn.audit import main as audit_main
+from atp_lean_gnn.dataset import DatasetRow
+from atp_lean_gnn.graph import proof_state_to_dag
+from atp_lean_gnn.labels import label_example
+from atp_lean_gnn.preparation import PreparationPhaseError, prepare_example
+
+
+class ParserAuditTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.output_root = Path("tests") / "_tmp_parser_audit"
+        if self.output_root.exists():
+            shutil.rmtree(self.output_root)
+
+    def tearDown(self) -> None:
+        if self.output_root.exists():
+            shutil.rmtree(self.output_root)
+
+    def _row(
+        self,
+        *,
+        state: str | None,
+        theorem: str,
+        tactic: str,
+        split: str = "train",
+        row_index: int = 0,
+    ) -> DatasetRow:
+        return DatasetRow(
+            state=state,
+            theorem=theorem,
+            tactic=tactic,
+            split=split,
+            row_index=row_index,
+            dataset_name="fake/dataset",
+        )
+
+    def test_prepare_example_classifies_failures_by_phase(self) -> None:
+        row = self._row(state="n : Nat\n|- n = n", theorem="demo", tactic="simp")
+
+        with patch("atp_lean_gnn.preparation.parse_state", side_effect=ValueError("bad state")):
+            with self.assertRaises(PreparationPhaseError) as parse_ctx:
+                prepare_example(row)
+        self.assertEqual(parse_ctx.exception.phase, "parse_state")
+        self.assertEqual(parse_ctx.exception.cause.__class__.__name__, "ValueError")
+
+        with patch("atp_lean_gnn.preparation.proof_state_to_dag", side_effect=RuntimeError("bad dag")):
+            with self.assertRaises(PreparationPhaseError) as dag_ctx:
+                prepare_example(row)
+        self.assertEqual(dag_ctx.exception.phase, "proof_state_to_dag")
+        self.assertEqual(dag_ctx.exception.cause.__class__.__name__, "RuntimeError")
+
+        with patch("atp_lean_gnn.preparation.label_example", side_effect=LookupError("bad label")):
+            with self.assertRaises(PreparationPhaseError) as label_ctx:
+                prepare_example(row)
+        self.assertEqual(label_ctx.exception.phase, "label_example")
+        self.assertEqual(label_ctx.exception.cause.__class__.__name__, "LookupError")
+
+    def test_build_failure_record_uses_phase_and_error_type_category(self) -> None:
+        row = self._row(state="n : Nat\n|- n = n", theorem="demo", tactic="simp")
+        exc = PreparationPhaseError(phase="proof_state_to_dag", cause=ValueError("broken dag"))
+
+        record = build_failure_record(row, exc)
+
+        self.assertEqual(record["phase"], "proof_state_to_dag")
+        self.assertEqual(record["error_type"], "ValueError")
+        self.assertEqual(record["failure_category"], "proof_state_to_dag:ValueError")
+
+    @patch("atp_lean_gnn.audit.iter_dataset_rows")
+    @patch("atp_lean_gnn.preparation.label_example")
+    @patch("atp_lean_gnn.preparation.proof_state_to_dag")
+    def test_run_parser_audit_writes_reports_and_categorized_failures(
+        self,
+        mock_proof_state_to_dag,
+        mock_label_example,
+        mock_iter_dataset_rows,
+    ) -> None:
+        real_proof_state_to_dag = proof_state_to_dag
+        real_label_example = label_example
+
+        def fake_iter_dataset_rows(*, dataset_name: str, split: str, sample_limit: int | None = None):
+            rows_by_split = {
+                "train": [
+                    self._row(state=None, theorem="bad.parse", tactic="simp", split="train", row_index=0),
+                    self._row(state="n : Nat\n|- FAIL_DAG", theorem="bad.dag", tactic="simp", split="train", row_index=1),
+                    self._row(state="m : Nat\n|- m = m", theorem="bad.label", tactic="fail_label", split="train", row_index=2),
+                    self._row(state="k : Nat\n|- k = k", theorem="good.train", tactic="simp", split="train", row_index=3),
+                ],
+                "val": [
+                    self._row(state="x : Nat\n|- x = x", theorem="good.val", tactic="rw [foo]", split="val", row_index=0),
+                ],
+            }
+            rows = rows_by_split[split]
+            if sample_limit is not None:
+                rows = rows[:sample_limit]
+            return iter(rows)
+
+        def fake_proof_state_to_dag(parsed_state):
+            if parsed_state.goal == "FAIL_DAG":
+                raise ValueError("dag failed")
+            return real_proof_state_to_dag(parsed_state)
+
+        def fake_label_example(raw_tactic: str):
+            if raw_tactic == "fail_label":
+                raise ValueError("label failed")
+            return real_label_example(raw_tactic)
+
+        mock_iter_dataset_rows.side_effect = fake_iter_dataset_rows
+        mock_proof_state_to_dag.side_effect = fake_proof_state_to_dag
+        mock_label_example.side_effect = fake_label_example
+
+        summary = run_parser_audit(
+            ParserAuditConfig(
+                dataset_name="fake/dataset",
+                splits=("train", "val"),
+                output_root=self.output_root,
+                sample_per_split=None,
+                max_examples_per_category=2,
+                force=True,
+            )
+        )
+
+        self.assertEqual(summary["overall"]["attempted_count"], 5)
+        self.assertEqual(summary["overall"]["success_count"], 2)
+        self.assertEqual(summary["overall"]["failure_count"], 3)
+        self.assertTrue((self.output_root / "reports" / "parser_audit.json").exists())
+        self.assertTrue((self.output_root / "reports" / "parser_audit.md").exists())
+        self.assertFalse((self.output_root / "train" / "json").exists())
+        self.assertFalse((self.output_root / "train" / "pyg").exists())
+
+        train_failures = (self.output_root / "failures" / "train.jsonl").read_text(encoding="utf-8").strip().splitlines()
+        self.assertEqual(len(train_failures), 3)
+        failure_records = [json.loads(line) for line in train_failures]
+        self.assertEqual(
+            {record["failure_category"] for record in failure_records},
+            {
+                "parse_state:TypeError",
+                "proof_state_to_dag:ValueError",
+                "label_example:ValueError",
+            },
+        )
+
+        manifest = json.loads((self.output_root / "manifests" / "train.json").read_text(encoding="utf-8"))
+        self.assertIn("representative_failure_examples", manifest)
+        self.assertIn("top_failure_phases", manifest)
+        self.assertEqual(manifest["attempted_count"], 4)
+        self.assertEqual(manifest["success_count"], 1)
+        self.assertEqual(manifest["failure_count"], 3)
+
+        summary_json = json.loads((self.output_root / "reports" / "parser_audit.json").read_text(encoding="utf-8"))
+        self.assertEqual(summary_json["splits_summary"]["val"]["success_count"], 1)
+        self.assertEqual(summary_json["top_failure_phases"][0]["count"], 1)
+        self.assertEqual(
+            {item["name"] for item in summary_json["recommended_follow_up_categories"]},
+            {
+                "parse_state:TypeError",
+                "proof_state_to_dag:ValueError",
+                "label_example:ValueError",
+            },
+        )
+
+        markdown = (self.output_root / "reports" / "parser_audit.md").read_text(encoding="utf-8")
+        self.assertIn("Parser Coverage Audit", markdown)
+        self.assertIn("Top Failure Categories", markdown)
+        self.assertIn("Representative Examples", markdown)
+
+    @patch("atp_lean_gnn.audit.iter_dataset_rows")
+    def test_audit_caps_representative_examples_per_category(self, mock_iter_dataset_rows) -> None:
+        def fake_iter_dataset_rows(*, dataset_name: str, split: str, sample_limit: int | None = None):
+            rows = [
+                self._row(state=None, theorem=f"bad.parse.{index}", tactic="simp", split="train", row_index=index)
+                for index in range(4)
+            ]
+            if sample_limit is not None:
+                rows = rows[:sample_limit]
+            return iter(rows)
+
+        mock_iter_dataset_rows.side_effect = fake_iter_dataset_rows
+
+        run_parser_audit(
+            ParserAuditConfig(
+                dataset_name="fake/dataset",
+                splits=("train",),
+                output_root=self.output_root,
+                max_examples_per_category=2,
+                force=True,
+            )
+        )
+
+        manifest = json.loads((self.output_root / "manifests" / "train.json").read_text(encoding="utf-8"))
+        examples = manifest["representative_failure_examples"]["parse_state:TypeError"]
+        self.assertEqual(len(examples), 2)
+
+    @patch("atp_lean_gnn.audit.iter_dataset_rows")
+    def test_audit_cli_supports_validation_alias_and_sample_limit(self, mock_iter_dataset_rows) -> None:
+        def fake_iter_dataset_rows(*, dataset_name: str, split: str, sample_limit: int | None = None):
+            rows_by_split = {
+                "train": [
+                    self._row(state="n : Nat\n|- n = n", theorem=f"train.{index}", tactic="simp", split="train", row_index=index)
+                    for index in range(3)
+                ],
+                "val": [
+                    self._row(state="m : Nat\n|- m = m", theorem=f"val.{index}", tactic="simp", split="val", row_index=index)
+                    for index in range(3)
+                ],
+            }
+            rows = rows_by_split[split]
+            if sample_limit is not None:
+                rows = rows[:sample_limit]
+            return iter(rows)
+
+        mock_iter_dataset_rows.side_effect = fake_iter_dataset_rows
+
+        exit_code = audit_main(
+            [
+                "--dataset-name",
+                "fake/dataset",
+                "--splits",
+                "train,validation",
+                "--output-root",
+                str(self.output_root),
+                "--sample-per-split",
+                "1",
+                "--force",
+            ]
+        )
+
+        self.assertEqual(exit_code, 0)
+        train_manifest = json.loads((self.output_root / "manifests" / "train.json").read_text(encoding="utf-8"))
+        val_manifest = json.loads((self.output_root / "manifests" / "val.json").read_text(encoding="utf-8"))
+        self.assertEqual(train_manifest["attempted_count"], 1)
+        self.assertEqual(val_manifest["attempted_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated parser audit command and package module
- share phase-aware preparation logic between preprocessing and auditing
- emit parser audit JSON/Markdown reports plus categorized failure logs
- add test coverage for phase classification, audit artifacts, and preprocessing regression

## Verification
- python -m unittest discover -s tests

Closes #1