### PR TITLE
Add LeanDojo integration for interactive tactic execution and proof search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ __pycache__
 *.rej
 artifacts/
 runs/
+
+test_dojo.py
+inspect_dataset.py 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The implementation now lives in the `atp_lean_gnn` package:
 - `reporting.py`: terminal-safe summaries and output helpers
 - `cli.py`: command-line entrypoint
 
+- `lean_env.py`: LeanDojo wrapper for executing tactics against Lean  
+- `replay.py`: replay gold-tactic traces through LeanDojo  
+- `search.py`: GNN-guided proof search loop via LeanDojo
+
 `main.py` remains as a thin compatibility wrapper, so `python main.py ...` still works.
 
 ## Common commands
@@ -88,6 +92,20 @@ Run the first scripted ablation suite for edge direction, readout, and node-type
 
 ```bash
 python scripts/run_ablation_suite.py --suite-config configs/ablations/issue4_suite.json
+```
+
+## LeanDojo Integration  
+  
+Replay gold-tactic traces through LeanDojo:  
+  
+```bash  
+python scripts/replay_proof.py --limit 3
+```
+
+Run GNN-guided proof search (requires a trained model):
+
+```bash
+python scripts/run_search.py --run-dir runs/baseline_gnn/run_YYYYMMDD_HHMMSS --limit 5
 ```
 
 ## Documentation

--- a/atp_lean_gnn/__init__.py
+++ b/atp_lean_gnn/__init__.py
@@ -34,6 +34,16 @@ from .training import (
 )
 from .visualize import build_visualization_html, visualize_dag
 
+try:  
+    from .lean_env import LeanEnvironment, StepResult, TheoremInfo, theorem_info_from_dataset_row  
+    _HAS_LEAN_ENV = True  
+except ImportError:  
+    _HAS_LEAN_ENV = False  
+  
+if _HAS_LEAN_ENV:  
+    from .replay import ReplaySummary, ReplayTrace, replay_proof  
+    from .search import SearchConfig, SearchTrace, greedy_search, predict_tactics, state_text_to_pyg
+
 __all__ = [
     "AblationSuiteConfig",
     "AblationVariant",
@@ -96,4 +106,16 @@ __all__ = [
     "UNKNOWN_TACTIC",
     "visualize_dag",
     "write_dag_json",
+    "LeanEnvironment",  
+    "StepResult",  
+    "TheoremInfo",  
+    "theorem_info_from_dataset_row",  
+    "ReplaySummary",  
+    "ReplayTrace",  
+    "replay_proof",  
+    "SearchConfig",  
+    "SearchTrace",  
+    "greedy_search",  
+    "predict_tactics",  
+    "state_text_to_pyg",
 ]

--- a/atp_lean_gnn/__init__.py
+++ b/atp_lean_gnn/__init__.py
@@ -36,6 +36,13 @@ from .visualize import build_visualization_html, visualize_dag
 
 try:  
     from .lean_env import LeanEnvironment, StepResult, TheoremInfo, theorem_info_from_dataset_row  
+    from .replay import ReplaySummary, ReplayTrace, replay_proof  
+    from .search import SearchConfig, SearchTrace, greedy_search, predict_tactics, state_text_to_pyg  
+except ImportError:  
+    pass
+
+try:  
+    from .lean_env import LeanEnvironment, StepResult, TheoremInfo, theorem_info_from_dataset_row  
     _HAS_LEAN_ENV = True  
 except ImportError:  
     _HAS_LEAN_ENV = False  

--- a/atp_lean_gnn/lean_env.py
+++ b/atp_lean_gnn/lean_env.py
@@ -1,0 +1,177 @@
+"""  
+Lean environment wrapper using LeanDojo.  
+  
+Provides: load theorem, get state, apply tactic, detect completion.  
+"""  
+  
+from __future__ import annotations  
+  
+import logging  
+from dataclasses import dataclass  
+from typing import Optional  
+  
+from lean_dojo import (  
+    Dojo,  
+    LeanGitRepo,  
+    ProofFinished,  
+    TacticState,  
+    Theorem,  
+)  
+  
+# These error classes live in a submodule in lean-dojo v4.20.0  
+try:  
+    from lean_dojo.interaction.dojo import (  
+        DojoTacticTimeoutError,  
+        DojoInitError,  
+        DojoCrashError,  
+    )  
+except ImportError:  
+    DojoTacticTimeoutError = Exception  
+    DojoInitError = Exception  
+    DojoCrashError = Exception  
+  
+
+try:  
+    from lean_dojo import LeanError  
+except ImportError:  
+    LeanError = Exception 
+  
+logger = logging.getLogger(__name__)  
+  
+  
+@dataclass(frozen=True)  
+class StepResult:  
+    """Result of applying one tactic."""  
+    success: bool  
+    state_text: str  
+    completed: bool  
+    error_message: str  
+    tactic: str  
+  
+  
+@dataclass(frozen=True)  
+class TheoremInfo:  
+    """Everything LeanDojo needs to load a theorem."""  
+    repo_url: str  
+    commit: str  
+    file_path: str       # e.g. "Mathlib/Data/Nat/Basic.lean"  
+    full_name: str        # e.g. "Nat.succ_ne_zero"  
+  
+  
+class LeanEnvironment:  
+    """  
+    Interactive Lean environment backed by LeanDojo.  
+  
+    Usage::  
+  
+        with LeanEnvironment() as env:  
+            state = env.load_theorem(info)  
+            result = env.apply_tactic("simp")  
+            if result.completed:  
+                print("Proof done!")  
+    """  
+  
+    def __init__(self) -> None:  
+        self._dojo: Optional[Dojo] = None  
+        self._current_state: Optional[TacticState] = None  
+        self._theorem_info: Optional[TheoremInfo] = None  
+        self._completed: bool = False  
+        self._dojo_context = None  
+  
+    def load_theorem(self, info: TheoremInfo) -> str:  
+        """Load a theorem and return the initial proof state text."""  
+        self.close()  
+  
+        repo = LeanGitRepo(info.repo_url, info.commit)  
+        theorem = Theorem(repo, info.file_path, info.full_name)  
+  
+        self._dojo_context = Dojo(theorem)  
+        dojo, initial_state = self._dojo_context.__enter__()  
+        self._dojo = dojo  
+        self._current_state = initial_state  
+        self._theorem_info = info  
+        self._completed = False  
+  
+        state_text = str(initial_state.pp)  
+        logger.info("Loaded %s — state: %s", info.full_name, state_text[:200])  
+        return state_text  
+  
+    def current_state(self) -> str:  
+        """Return current proof state as text."""  
+        if self._current_state is None:  
+            raise RuntimeError("No theorem loaded. Call load_theorem() first.")  
+        return str(self._current_state.pp)  
+  
+    def is_complete(self) -> bool:  
+        return self._completed  
+  
+    def apply_tactic(self, tactic: str) -> StepResult:  
+        """Apply a tactic string. Returns StepResult."""  
+        if self._dojo is None or self._current_state is None:  
+            raise RuntimeError("No theorem loaded.")  
+        if self._completed:  
+            raise RuntimeError("Proof already complete.")  
+  
+        try:  
+            result = self._dojo.run_tac(self._current_state, tactic)  
+        except (DojoTimeoutError, Exception) as exc:  
+            logger.warning("Tactic '%s' raised: %s", tactic, exc)  
+            return StepResult(  
+                success=False, state_text="", completed=False,  
+                error_message=str(exc), tactic=tactic,  
+            )  
+  
+        if isinstance(result, ProofFinished):  
+            self._completed = True  
+            return StepResult(  
+                success=True, state_text="", completed=True,  
+                error_message="", tactic=tactic,  
+            )  
+  
+        if isinstance(result, TacticState):  
+            self._current_state = result  
+            return StepResult(  
+                success=True, state_text=str(result.pp), completed=False,  
+                error_message="", tactic=tactic,  
+            )  
+  
+        # LeanError or other failure  
+        error_msg = str(result) if isinstance(result, LeanError) else repr(result)  
+        return StepResult(  
+            success=False, state_text="", completed=False,  
+            error_message=error_msg, tactic=tactic,  
+        )  
+  
+    def close(self) -> None:  
+        if self._dojo_context is not None:  
+            try:  
+                self._dojo_context.__exit__(None, None, None)  
+            except Exception as exc:  
+                logger.warning("Error closing Dojo: %s", exc)  
+        self._dojo = None  
+        self._current_state = None  
+        self._theorem_info = None  
+        self._completed = False  
+        self._dojo_context = None  
+  
+    def __enter__(self):  
+        return self  
+  
+    def __exit__(self, *args):  
+        self.close()  
+  
+  
+def theorem_info_from_dataset_row(row: dict) -> TheoremInfo:  
+    """  
+    Build TheoremInfo from a raw HuggingFace dataset row.  
+  
+    The LeanDojo benchmark rows have: url, commit, file_path, full_name.  
+    Verify these field names match your dataset version by running  
+    inspect_dataset.py first.  
+    """  
+    return TheoremInfo(  
+        repo_url=row["url"],  
+        commit=row["commit"],  
+        file_path=row["file_path"],  
+        full_name=row["full_name"],  
+    )

--- a/atp_lean_gnn/lean_env.py
+++ b/atp_lean_gnn/lean_env.py
@@ -85,7 +85,7 @@ class LeanEnvironment:
         repo = LeanGitRepo(info.repo_url, info.commit)  
         theorem = Theorem(repo, info.file_path, info.full_name)  
   
-        self._dojo_context = Dojo(theorem)  
+        self._dojo_context = Dojo(theorem, timeout=1200)  # 20 min timeout for loading/initialization
         dojo, initial_state = self._dojo_context.__enter__()  
         self._dojo = dojo  
         self._current_state = initial_state  
@@ -114,7 +114,7 @@ class LeanEnvironment:
   
         try:  
             result = self._dojo.run_tac(self._current_state, tactic)  
-        except (DojoTimeoutError, Exception) as exc:  
+        except Exception as exc:  
             logger.warning("Tactic '%s' raised: %s", tactic, exc)  
             return StepResult(  
                 success=False, state_text="", completed=False,  

--- a/atp_lean_gnn/replay.py
+++ b/atp_lean_gnn/replay.py
@@ -1,0 +1,118 @@
+"""  
+Gold-trace proof replay through the Lean environment.  
+"""  
+  
+from __future__ import annotations  
+  
+import json  
+import logging  
+from dataclasses import dataclass, field  
+from pathlib import Path  
+from typing import Optional  
+  
+from .lean_env import LeanEnvironment, StepResult, TheoremInfo  
+  
+logger = logging.getLogger(__name__)  
+  
+  
+@dataclass(frozen=True)  
+class ReplayStep:  
+    step_index: int  
+    tactic: str  
+    result: StepResult  
+    state_before: str  
+  
+  
+@dataclass  
+class ReplayTrace:  
+    theorem_info: TheoremInfo  
+    initial_state: str  
+    steps: list[ReplayStep] = field(default_factory=list)  
+    success: bool = False  
+    error_step: Optional[int] = None  
+    error_message: str = ""  
+  
+    def to_dict(self) -> dict:  
+        return {  
+            "theorem": self.theorem_info.full_name,  
+            "file_path": self.theorem_info.file_path,  
+            "initial_state": self.initial_state,  
+            "success": self.success,  
+            "num_steps": len(self.steps),  
+            "error_step": self.error_step,  
+            "error_message": self.error_message,  
+            "steps": [  
+                {  
+                    "step_index": s.step_index,  
+                    "tactic": s.tactic,  
+                    "success": s.result.success,  
+                    "completed": s.result.completed,  
+                    "state_before": s.state_before,  
+                    "state_after": s.result.state_text,  
+                    "error": s.result.error_message,  
+                }  
+                for s in self.steps  
+            ],  
+        }  
+  
+  
+def replay_proof(  
+    env: LeanEnvironment,  
+    theorem_info: TheoremInfo,  
+    tactics: list[str],  
+) -> ReplayTrace:  
+    """Replay a known tactic sequence on a theorem."""  
+    initial_state = env.load_theorem(theorem_info)  
+    trace = ReplayTrace(theorem_info=theorem_info, initial_state=initial_state)  
+  
+    for i, tactic in enumerate(tactics):  
+        state_before = env.current_state()  
+        result = env.apply_tactic(tactic)  
+  
+        trace.steps.append(ReplayStep(  
+            step_index=i, tactic=tactic,  
+            result=result, state_before=state_before,  
+        ))  
+  
+        if not result.success:  
+            trace.error_step = i  
+            trace.error_message = result.error_message  
+            return trace  
+  
+        if result.completed:  
+            trace.success = True  
+            return trace  
+  
+    trace.error_message = "All tactics applied but proof not complete"  
+    return trace  
+  
+  
+@dataclass  
+class ReplaySummary:  
+    total: int = 0  
+    succeeded: int = 0  
+    failed: int = 0  
+    traces: list[ReplayTrace] = field(default_factory=list)  
+  
+    def add(self, trace: ReplayTrace) -> None:  
+        self.total += 1  
+        if trace.success:  
+            self.succeeded += 1  
+        else:  
+            self.failed += 1  
+        self.traces.append(trace)  
+  
+    def success_rate(self) -> float:  
+        return self.succeeded / self.total if self.total > 0 else 0.0  
+  
+    def save(self, path: str | Path) -> Path:  
+        out = Path(path)  
+        out.parent.mkdir(parents=True, exist_ok=True)  
+        out.write_text(json.dumps({  
+            "total": self.total,  
+            "succeeded": self.succeeded,  
+            "failed": self.failed,  
+            "success_rate": self.success_rate(),  
+            "traces": [t.to_dict() for t in self.traces],  
+        }, indent=2, ensure_ascii=False), encoding="utf-8")  
+        return out

--- a/atp_lean_gnn/search.py
+++ b/atp_lean_gnn/search.py
@@ -1,0 +1,215 @@
+"""  
+Proof search loop: GNN tactic prediction + LeanDojo environment stepping.  
+"""  
+  
+from __future__ import annotations  
+  
+import json  
+import logging  
+from dataclasses import dataclass, field  
+from pathlib import Path  
+  
+import torch  
+  
+from .graph import proof_state_to_dag  
+from .lean_env import LeanEnvironment, StepResult, TheoremInfo  
+from .model import GraphSAGEStateClassifier  
+from .pyg import dag_to_pyg  
+from .state import parse_state  
+from .training import PreparedMetadata, infer_state_node_index, transform_edge_index  
+  
+logger = logging.getLogger(__name__)  
+  
+  
+# ── Config ────────────────────────────────────────────────────────────  
+  
+@dataclass(frozen=True)  
+class SearchConfig:  
+    beam_width: int = 5       # top-k tactics to try per step  
+    max_depth: int = 50       # max proof steps  
+    edge_mode: str = "bidirectional"  
+  
+  
+# ── Trace types ───────────────────────────────────────────────────────  
+  
+@dataclass  
+class SearchStep:  
+    depth: int  
+    state_text: str  
+    tactic_tried: str  
+    tactic_rank: int  
+    probability: float  
+    success: bool  
+    completed: bool  
+    error_message: str = ""  
+  
+  
+@dataclass  
+class SearchTrace:  
+    theorem_info: TheoremInfo  
+    initial_state: str  
+    steps: list[SearchStep] = field(default_factory=list)  
+    solved: bool = False  
+    final_depth: int = 0  
+    failure_reason: str = ""  
+  
+    def to_dict(self) -> dict:  
+        return {  
+            "theorem": self.theorem_info.full_name,  
+            "file_path": self.theorem_info.file_path,  
+            "solved": self.solved,  
+            "final_depth": self.final_depth,  
+            "failure_reason": self.failure_reason,  
+            "num_steps_tried": len(self.steps),  
+            "steps": [  
+                {  
+                    "depth": s.depth,  
+                    "tactic": s.tactic_tried,  
+                    "rank": s.tactic_rank,  
+                    "probability": s.probability,  
+                    "success": s.success,  
+                    "completed": s.completed,  
+                    "error": s.error_message,  
+                }  
+                for s in self.steps  
+            ],  
+        }  
+  
+  
+# ── Bridge: live state text → PyG graph ──────────────────────────────  
+  
+def state_text_to_pyg(  
+    state_text: str,  
+    metadata: PreparedMetadata,  
+    *,  
+    edge_mode: str = "bidirectional",  
+    device: torch.device = torch.device("cpu"),  
+):  
+    """  
+    Convert a live proof state string (from LeanDojo) into a PyG Data  
+    object ready for the GNN.  
+  
+    Reuses the existing offline pipeline:  
+      state text → parse_state() → proof_state_to_dag() → dag_to_pyg()  
+    Then adds the fields the model expects (state_node_index, edge transforms).  
+    """  
+    parsed = parse_state(state_text)  
+    dag = proof_state_to_dag(parsed)  
+    data = dag_to_pyg(dag, metadata.node_vocab)  
+  
+    data.x = data.x.to(dtype=torch.long)  
+    data.node_type = data.node_type.to(dtype=torch.long)  
+    data.edge_index = transform_edge_index(data.edge_index, edge_mode=edge_mode)  
+    data.state_node_index = infer_state_node_index(  
+        data,  
+        state_label_id=metadata.state_label_id,  
+        path=Path("<live>"),  
+    )  
+  
+    return data.to(device)  
+  
+  
+# ── Tactic prediction ────────────────────────────────────────────────  
+  
+def predict_tactics(  
+    model: GraphSAGEStateClassifier,  
+    data,  
+    *,  
+    tactic_vocab: dict[str, int],  
+    top_k: int = 5,  
+) -> list[tuple[str, float]]:  
+    """  
+    Run the GNN on a proof state graph and return top-k  
+    predicted tactic names with probabilities.  
+    """  
+    id_to_tactic = {v: k for k, v in tactic_vocab.items()}  
+  
+    model.eval()  
+    with torch.no_grad():  
+        logits = model(data)                    # [1, num_tactics]  
+        probs = torch.softmax(logits, dim=-1)  
+        top_probs, top_indices = probs.topk(top_k, dim=-1)  
+  
+    results = []  
+    for prob, idx in zip(top_probs[0], top_indices[0]):  
+        name = id_to_tactic.get(int(idx.item()), "<UNK>")  
+        results.append((name, float(prob.item())))  
+    return results  
+  
+  
+# ── Search loop ───────────────────────────────────────────────────────  
+  
+def greedy_search(  
+    model: GraphSAGEStateClassifier,  
+    env: LeanEnvironment,  
+    theorem_info: TheoremInfo,  
+    metadata: PreparedMetadata,  
+    config: SearchConfig,  
+    *,  
+    device: torch.device = torch.device("cpu"),  
+) -> SearchTrace:  
+    """  
+    Greedy proof search: at each step, try top-k predicted tactics  
+    and take the first one that succeeds.  
+  
+    IMPORTANT: The model predicts tactic HEADS only (e.g. 'simp'),  
+    not full tactics with arguments (e.g. 'rw [h]'). Only argument-free  
+    tactics will actually work until premise selection is added.  
+    """  
+    initial_state = env.load_theorem(theorem_info)  
+    trace = SearchTrace(theorem_info=theorem_info, initial_state=initial_state)  
+  
+    for depth in range(config.max_depth):  
+        state_text = env.current_state()  
+  
+        # Convert live state → PyG graph  
+        try:  
+            data = state_text_to_pyg(  
+                state_text, metadata,  
+                edge_mode=config.edge_mode, device=device,  
+            )  
+        except Exception as exc:  
+            trace.failure_reason = f"Graph conversion failed at depth {depth}: {exc}"  
+            break  
+  
+        # Get model predictions  
+        candidates = predict_tactics(  
+            model, data,  
+            tactic_vocab=metadata.tactic_vocab,  
+            top_k=config.beam_width,  
+        )  
+  
+        # Try each candidate tactic  
+        step_succeeded = False  
+        for rank, (tactic_name, prob) in enumerate(candidates):  
+            result = env.apply_tactic(tactic_name)  
+  
+            trace.steps.append(SearchStep(  
+                depth=depth, state_text=state_text,  
+                tactic_tried=tactic_name, tactic_rank=rank,  
+                probability=prob,  
+                success=result.success, completed=result.completed,  
+                error_message=result.error_message,  
+            ))  
+  
+            if result.completed:  
+                trace.solved = True  
+                trace.final_depth = depth + 1  
+                return trace  
+  
+            if result.success:  
+                step_succeeded = True  
+                break  
+  
+        if not step_succeeded:  
+            trace.failure_reason = (  
+                f"All {config.beam_width} candidates failed at depth {depth}"  
+            )  
+            trace.final_depth = depth  
+            break  
+  
+    if not trace.solved and not trace.failure_reason:  
+        trace.failure_reason = f"Max depth {config.max_depth} reached"  
+        trace.final_depth = config.max_depth  
+  
+    return trace

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@
 datasets>=2.20
 torch>=2.4
 torch-geometric>=2.5
+lean-dojo>=2.1

--- a/scripts/replay_proof.py
+++ b/scripts/replay_proof.py
@@ -1,0 +1,79 @@
+"""  
+Replay gold tactic traces from the dataset through LeanDojo.  
+  
+Usage:  
+    python scripts/replay_proof.py --limit 5  
+    python scripts/replay_proof.py --limit 10 --split test --output artifacts/replay/results.json  
+"""  
+  
+from __future__ import annotations  
+  
+import argparse  
+import sys  
+from pathlib import Path  
+  
+if __package__ in {None, ""}:  
+    repo_root = Path(__file__).resolve().parents[1]  
+    if str(repo_root) not in sys.path:  
+        sys.path.insert(0, str(repo_root))  
+  
+from datasets import load_dataset  
+  
+from atp_lean_gnn.dataset import dataset_split_name  
+from atp_lean_gnn.lean_env import LeanEnvironment, theorem_info_from_dataset_row  
+from atp_lean_gnn.replay import ReplaySummary, replay_proof  
+from atp_lean_gnn.reporting import console_print  
+  
+  
+def main(argv: list[str] | None = None) -> int:  
+    parser = argparse.ArgumentParser(description="Replay gold tactic traces")  
+    parser.add_argument("--limit", type=int, default=5)  
+    parser.add_argument("--split", type=str, default="test")  
+    parser.add_argument("--output", type=str, default="artifacts/replay/results.json")  
+    parser.add_argument("--dataset-name", type=str,  
+                        default="cat-searcher/leandojo-benchmark-4-random")  
+    args = parser.parse_args(argv)  
+  
+    hf_split = dataset_split_name(args.split)  
+    console_print(f"\n  Loading dataset split={hf_split}...")  
+  
+    ds = load_dataset(args.dataset_name, split=hf_split, streaming=True)  
+  
+    # Group rows by theorem to reconstruct full tactic traces.  
+    # Each HF row is one tactic step; multiple rows share the same full_name.  
+    theorem_traces: dict[str, dict] = {}  
+    for row in ds:  
+        full_name = row.get("full_name", "")  
+        if not full_name:  
+            continue  
+        if full_name not in theorem_traces:  
+            theorem_traces[full_name] = {  
+                "info": theorem_info_from_dataset_row(row),  
+                "tactics": [],  
+            }  
+            if len(theorem_traces) > args.limit:  
+                break  
+        theorem_traces[full_name]["tactics"].append(row.get("tactic", ""))  
+  
+    console_print(f"  Collected {len(theorem_traces)} theorem traces")  
+  
+    summary = ReplaySummary()  
+    with LeanEnvironment() as env:  
+        for name, data in list(theorem_traces.items())[:args.limit]:  
+            console_print(f"\n  Replaying: {name} ({len(data['tactics'])} steps)")  
+            try:  
+                trace = replay_proof(env, data["info"], data["tactics"])  
+                summary.add(trace)  
+                status = "OK" if trace.success else f"FAIL step {trace.error_step}"  
+                console_print(f"    {status}")  
+            except Exception as exc:  
+                console_print(f"    ERROR: {exc}")  
+  
+    out_path = summary.save(args.output)  
+    console_print(f"\n  {summary.succeeded}/{summary.total} succeeded")  
+    console_print(f"  Saved: {out_path}")  
+    return 0  
+  
+  
+if __name__ == "__main__":  
+    raise SystemExit(main())

--- a/scripts/replay_proof.py
+++ b/scripts/replay_proof.py
@@ -10,7 +10,8 @@ from __future__ import annotations
   
 import argparse  
 import sys  
-from pathlib import Path  
+from pathlib import Path 
+import re  
   
 if __package__ in {None, ""}:  
     repo_root = Path(__file__).resolve().parents[1]  
@@ -23,7 +24,10 @@ from atp_lean_gnn.dataset import dataset_split_name
 from atp_lean_gnn.lean_env import LeanEnvironment, theorem_info_from_dataset_row  
 from atp_lean_gnn.replay import ReplaySummary, replay_proof  
 from atp_lean_gnn.reporting import console_print  
-  
+
+def strip_lean_dojo_tags(tactic: str) -> str:  
+    """Remove <a>...</a> premise annotations that LeanDojo adds to tactics."""  
+    return re.sub(r"</?a[^>]*>", "", tactic)
   
 def main(argv: list[str] | None = None) -> int:  
     parser = argparse.ArgumentParser(description="Replay gold tactic traces")  
@@ -53,7 +57,7 @@ def main(argv: list[str] | None = None) -> int:
             }  
             if len(theorem_traces) > args.limit:  
                 break  
-        theorem_traces[full_name]["tactics"].append(row.get("tactic", ""))  
+        theorem_traces[full_name]["tactics"].append(strip_lean_dojo_tags(row.get("tactic", "")))  
   
     console_print(f"  Collected {len(theorem_traces)} theorem traces")  
   

--- a/scripts/run_search.py
+++ b/scripts/run_search.py
@@ -1,0 +1,124 @@
+"""  
+Run proof search: GNN predictions + LeanDojo execution.  
+  
+Usage:  
+    python scripts/run_search.py \  
+        --run-dir runs/baseline_gnn/run_XXXXXXXX_XXXXXX \  
+        --limit 10  
+"""  
+  
+from __future__ import annotations  
+  
+import argparse  
+import json  
+import sys  
+from pathlib import Path  
+  
+if __package__ in {None, ""}:  
+    repo_root = Path(__file__).resolve().parents[1]  
+    if str(repo_root) not in sys.path:  
+        sys.path.insert(0, str(repo_root))  
+  
+import torch  
+from datasets import load_dataset  
+  
+from atp_lean_gnn.dataset import dataset_split_name  
+from atp_lean_gnn.lean_env import LeanEnvironment, theorem_info_from_dataset_row  
+from atp_lean_gnn.reporting import console_print  
+from atp_lean_gnn.search import SearchConfig, greedy_search  
+from atp_lean_gnn.training import (  
+    build_model,  
+    load_baseline_config,  
+    load_prepared_metadata,  
+    resolve_device,  
+)  
+  
+  
+def main(argv: list[str] | None = None) -> int:  
+    parser = argparse.ArgumentParser(description="Proof search with GNN + LeanDojo")  
+    parser.add_argument("--run-dir", type=str, required=True,  
+                        help="Path to a trained run directory (contains best.pt)")  
+    parser.add_argument("--limit", type=int, default=5)  
+    parser.add_argument("--beam-width", type=int, default=5)  
+    parser.add_argument("--max-depth", type=int, default=50)  
+    parser.add_argument("--split", type=str, default="test")  
+    parser.add_argument("--output", type=str, default=None)  
+    args = parser.parse_args(argv)  
+  
+    run_dir = Path(args.run_dir)  
+  
+    # Load config and metadata from the training run  
+    config = load_baseline_config(run_dir / "config.json")  
+    metadata = load_prepared_metadata(config.prepared_root)  
+    device = resolve_device(config.device)  
+  
+    # Load trained model  
+    model = build_model(metadata, config).to(device)  
+    checkpoint = torch.load(  
+        run_dir / "best.pt", map_location=device, weights_only=False,  
+    )  
+    model.load_state_dict(checkpoint["model_state_dict"])  
+    model.eval()  
+    console_print(f"  Loaded model from {run_dir / 'best.pt'}")  
+  
+    search_config = SearchConfig(  
+        beam_width=args.beam_width,  
+        max_depth=args.max_depth,  
+        edge_mode=config.edge_mode,  
+    )  
+  
+    # Load unique theorems from dataset  
+    hf_split = dataset_split_name(args.split)  
+    ds = load_dataset(  
+        "cat-searcher/leandojo-benchmark-4-random",  
+        split=hf_split, streaming=True,  
+    )  
+    seen: set[str] = set()  
+    theorem_list = []  
+    for row in ds:  
+        name = row.get("full_name", "")  
+        if name and name not in seen:  
+            seen.add(name)  
+            theorem_list.append(theorem_info_from_dataset_row(row))  
+        if len(theorem_list) >= args.limit:  
+            break  
+  
+    # Run search  
+    results = []  
+    solved_count = 0  
+    with LeanEnvironment() as env:  
+        for i, info in enumerate(theorem_list):  
+            console_print(f"\n  [{i+1}/{len(theorem_list)}] {info.full_name}")  
+            try:  
+                trace = greedy_search(  
+                    model, env, info, metadata, search_config,  
+                    device=device,  
+                )  
+                results.append(trace.to_dict())  
+                if trace.solved:  
+                    solved_count += 1  
+                    console_print(f"    SOLVED in {trace.final_depth} steps")  
+                else:  
+                    console_print(f"    FAILED: {trace.failure_reason}")  
+            except Exception as exc:  
+                console_print(f"    ERROR: {exc}")  
+                results.append({"theorem": info.full_name, "error": str(exc)})  
+  
+    # Save  
+    output_path = Path(args.output or f"artifacts/search/results_{args.split}.json")  
+    output_path.parent.mkdir(parents=True, exist_ok=True)  
+    output_path.write_text(json.dumps({  
+        "total": len(theorem_list),  
+        "solved": solved_count,  
+        "success_rate": solved_count / max(len(theorem_list), 1),  
+        "config": {"beam_width": search_config.beam_width, "max_depth": search_config.max_depth},  
+        "results": results,  
+    }, indent=2), encoding="utf-8")  
+  
+    console_print(f"\n  {solved_count}/{len(theorem_list)} solved")  
+    console_print(f"  Saved: {output_path}")  
+    return 0  
+  
+  
+if __name__ == "__main__":  
+    raise SystemExit(main())

--- a/tests/test_lean_env.py
+++ b/tests/test_lean_env.py
@@ -4,7 +4,7 @@ Skipped if lean-dojo is not installed.
 """  
   
 from __future__ import annotations  
-  
+import re 
 import pytest  
   
 try:  
@@ -36,8 +36,9 @@ def test_load_and_apply():
         assert len(state) > 0  
         assert not env.is_complete()  
   
-        # Apply the gold tactic from the dataset  
-        result = env.apply_tactic(row["tactic"])  
+        # Strip <a>...</a> tags and apply the gold tactic  
+        tactic = re.sub(r"</?a[^>]*>", "", row["tactic"])  
+        result = env.apply_tactic(tactic) 
         # It should either succeed or give a clean error  
         assert result.success or len(result.error_message) > 0  
   

--- a/tests/test_lean_env.py
+++ b/tests/test_lean_env.py
@@ -1,0 +1,61 @@
+"""  
+Smoke tests for the LeanDojo environment wrapper.  
+Skipped if lean-dojo is not installed.  
+"""  
+  
+from __future__ import annotations  
+  
+import pytest  
+  
+try:  
+    import lean_dojo  
+    HAS_LEAN_DOJO = True  
+except ImportError:  
+    HAS_LEAN_DOJO = False  
+  
+requires_leandojo = pytest.mark.skipif(not HAS_LEAN_DOJO, reason="lean-dojo not installed")  
+  
+  
+@requires_leandojo  
+def test_load_and_apply():  
+    """Load a theorem, apply a tactic, verify we get a result."""  
+    from datasets import load_dataset  
+    from atp_lean_gnn.lean_env import LeanEnvironment, theorem_info_from_dataset_row  
+  
+    # Grab one real row from the dataset  
+    ds = load_dataset(  
+        "cat-searcher/leandojo-benchmark-4-random",  
+        split="test", streaming=True,  
+    )  
+    row = next(iter(ds))  
+    info = theorem_info_from_dataset_row(row)  
+  
+    with LeanEnvironment() as env:  
+        state = env.load_theorem(info)  
+        assert isinstance(state, str)  
+        assert len(state) > 0  
+        assert not env.is_complete()  
+  
+        # Apply the gold tactic from the dataset  
+        result = env.apply_tactic(row["tactic"])  
+        # It should either succeed or give a clean error  
+        assert result.success or len(result.error_message) > 0  
+  
+  
+@requires_leandojo  
+def test_invalid_tactic():  
+    from datasets import load_dataset  
+    from atp_lean_gnn.lean_env import LeanEnvironment, theorem_info_from_dataset_row  
+  
+    ds = load_dataset(  
+        "cat-searcher/leandojo-benchmark-4-random",  
+        split="test", streaming=True,  
+    )  
+    row = next(iter(ds))  
+    info = theorem_info_from_dataset_row(row)  
+  
+    with LeanEnvironment() as env:  
+        env.load_theorem(info)  
+        result = env.apply_tactic("not_a_real_tactic_xyz")  
+        assert not result.success  
+        assert len(result.error_message) > 0

--- a/tests/test_search_bridge.py
+++ b/tests/test_search_bridge.py
@@ -1,0 +1,44 @@
+"""  
+Unit tests for the state-to-graph bridge used in search.  
+No LeanDojo required.  
+"""  
+  
+from __future__ import annotations  
+  
+from atp_lean_gnn.graph import proof_state_to_dag  
+from atp_lean_gnn.pyg import build_vocab, dag_to_pyg  
+from atp_lean_gnn.state import parse_state  
+  
+  
+def test_live_state_roundtrip():  
+    """Simulate converting a live proof state through the pipeline."""  
+    # This is what LeanDojo's state.pp would return  
+    state_text = "n : ℕ\n⊢ 0 + n = n"  
+  
+    parsed = parse_state(state_text)  
+    assert parsed.goal == "0 + n = n"  
+    assert len(parsed.hypotheses) == 1  
+    assert parsed.hypotheses[0].name == "n"  
+  
+    dag = proof_state_to_dag(parsed)  
+    assert dag.num_nodes > 0  
+  
+    vocab = build_vocab([dag])  
+    data = dag_to_pyg(dag, vocab)  
+  
+    assert data.x.dim() == 1  
+    assert data.edge_index.dim() == 2  
+    assert data.num_nodes == dag.num_nodes  
+  
+  
+def test_multiple_hypotheses():  
+    state_text = "a : ℕ\nb : ℕ\nh : a = b\n⊢ a + 1 = b + 1"  
+  
+    parsed = parse_state(state_text)  
+    assert len(parsed.hypotheses) == 3  
+    assert parsed.goal == "a + 1 = b + 1"  
+  
+    dag = proof_state_to_dag(parsed)  
+    vocab = build_vocab([dag])  
+    data = dag_to_pyg(dag, vocab)  
+    assert data.num_nodes > 0


### PR DESCRIPTION
## Summary  
This PR adds LeanDojo integration to enable the baseline GNN to execute predicted tactics against a real Lean environment and generate the next proof state. Previously, the system only predicted tactic heads offline.  
  
## Changes  
  
### New modules  
- `atp_lean_gnn/lean_env.py` — LeanDojo wrapper for loading theorems and applying tactics  
- `atp_lean_gnn/replay.py` — gold-trace proof replay through LeanDojo  
- `atp_lean_gnn/search.py` — GNN-guided proof search loop connecting the model to LeanDojo  
  
### New scripts  
- `scripts/replay_proof.py` — replay gold-tactic traces from the dataset  
- `scripts/run_search.py` — run GNN-guided proof search (requires trained model)  
  
### New tests  
- `tests/test_lean_env.py` — smoke tests for LeanDojo wrapper (2 tests)  
- `tests/test_search_bridge.py` — unit tests for state→graph bridge (2 tests)  
  
### Modified files  
- `atp_lean_gnn/__init__.py` — added imports for new modules
- `.gitignore` — added temporary test scripts  
- `README.md` — added LeanDojo integration section with usage examples  
  
## Testing  
All tests pass:  
- Module imports: OK  
- `test_search_bridge.py`: 2/2 passed  
- `test_lean_env.py`: 2/2 passed  
- Full test suite: 36/36 passed  
- Gold-trace replay: 3/3 theorems succeeded  
  
## Usage  
```bash  
# Replay gold-tactic traces  
python scripts/replay_proof.py --limit 3  
  
# Run GNN-guided search (requires trained model)  
python scripts/run_search.py --run-dir runs/baseline_gnn/run_YYYYMMDD_HHMMSS --limit 5