### PR TITLE
Lib premise selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ __pycache__
 *.rej
 artifacts/
 runs/
+.pytest_cache/
+

--- a/atp_lean_gnn/__init__.py
+++ b/atp_lean_gnn/__init__.py
@@ -14,7 +14,9 @@ from .analysis import analyze_saved_run, compare_saved_runs, load_metrics_histor
 from .cache import SplitReport, build_failure_record, build_json_payload
 from .cli import DEMO_STATE
 from .dataset import DatasetRow, iter_dataset_rows
-from .graph import DAGBuilder, GraphNode, GraphStats, dag_to_dict, graph_stats, proof_state_to_dag, write_dag_json
+from .graph import DAGBuilder, GraphNode, GraphStats, dag_to_dict, graph_stats, lemma_statement_to_dag, proof_state_to_dag, write_dag_json
+from .inference import InferencePipeline
+from .lemma_corpus import LemmaRecord, load_lemma_corpus, load_lemma_name_index
 from .labels import (
     DEFAULT_ARITY,
     EMPTY_TACTIC,
@@ -27,12 +29,14 @@ from .labels import (
     normalize_tactic,
     parse_tactic_arguments,
 )
+from .lemma_index import LemmaIndex, LemmaIndexConfig
 from .model import GraphSAGEClassifierConfig, GraphSAGEStateClassifier
-from .preprocess import DEFAULT_OUTPUT_ROOT, PreprocessConfig, prepare_example, run_preprocessing
-from .pyg import NODE_TYPE_TO_ID, build_premise_mask, build_vocab, build_vocab_from_labels, dag_to_pyg
 from .preparation import PreparedExample, prepare_example
+from .premise_pool import CandidatePool, build_unified_pools
+from .premise_scoring import PremiseScorer, PremiseScorerConfig, compute_premise_ranking_loss
+from .premise_training import evaluate_model_with_premises, train_one_epoch_with_premises
 from .preprocess import DEFAULT_OUTPUT_ROOT, PreprocessConfig, run_preprocessing
-from .pyg import NODE_TYPE_TO_ID, build_vocab, build_vocab_from_labels, dag_to_pyg
+from .pyg import NODE_TYPE_TO_ID, build_premise_mask, build_vocab, build_vocab_from_labels, dag_to_pyg
 from .state import Hypothesis, ProofState, parse_state
 from .training import (
     DEFAULT_BASELINE_CONFIG_PATH,
@@ -53,9 +57,9 @@ from .visualize import build_visualization_html, visualize_dag
 __all__ = [
     "ArgumentSelector",
     "BaselineConfig",
+    "CandidatePool",
     "DAGBuilder",
     "DEFAULT_ARITY",
-    "DEMO_STATE",
     "DEFAULT_AUDIT_OUTPUT_ROOT",
     "DEFAULT_BASELINE_CONFIG_PATH",
     "DEFAULT_OUTPUT_ROOT",
@@ -67,41 +71,55 @@ __all__ = [
     "GraphSAGEStateClassifier",
     "GraphStats",
     "Hypothesis",
+    "InferencePipeline",
+    "LemmaIndex",
+    "LemmaIndexConfig",
+    "LemmaRecord",
     "NODE_TYPE_TO_ID",
+    "ParserAuditConfig",
+    "PreparedExample",
     "PreparedGraphDataset",
     "PreparedMetadata",
-    "PreparedExample",
-    "ProofState",
-    "ParserAuditConfig",
+    "PremiseScorer",
+    "PremiseScorerConfig",
     "PreprocessConfig",
+    "ProofState",
+    "SplitReport",
     "TACTIC_ARITY",
     "TacticWithArgsClassifier",
     "TacticWithArgsConfig",
     "TrainingLoopConfig",
+    "UNKNOWN_TACTIC",
     "analyze_saved_run",
-    "build_visualization_html",
     "build_dataloaders",
     "build_failure_record",
     "build_json_payload",
     "build_premise_mask",
     "build_tactic_vocab",
+    "build_unified_pools",
+    "build_visualization_html",
     "build_vocab",
     "build_vocab_from_labels",
-    "compute_combined_loss",
     "compare_saved_runs",
+    "compute_combined_loss",
     "compute_eval_metrics_from_logits",
+    "compute_premise_ranking_loss",
     "dag_to_dict",
     "dag_to_pyg",
     "encode_tactic_name",
     "evaluate_baseline_run",
     "evaluate_model",
     "evaluate_model_with_args",
+    "evaluate_model_with_premises",
     "get_tactic_arity",
     "graph_stats",
     "iter_dataset_rows",
     "label_example",
-    "load_metrics_history",
+    "lemma_statement_to_dag",
     "load_baseline_config",
+    "load_lemma_corpus",
+    "load_lemma_name_index",
+    "load_metrics_history",
     "load_prepared_metadata",
     "load_run_summary",
     "normalize_tactic",
@@ -109,14 +127,13 @@ __all__ = [
     "parse_tactic_arguments",
     "prepare_example",
     "proof_state_to_dag",
-    "resolve_arg_targets_to_padded",
     "render_run_comparison_markdown",
+    "resolve_arg_targets_to_padded",
     "run_parser_audit",
     "run_preprocessing",
-    "SplitReport",
     "train_baseline",
     "train_one_epoch_with_args",
-    "UNKNOWN_TACTIC",
+    "train_one_epoch_with_premises",
     "visualize_dag",
     "write_dag_json",
 ]

--- a/atp_lean_gnn/argument_selector.py
+++ b/atp_lean_gnn/argument_selector.py
@@ -335,11 +335,14 @@ def compute_combined_loss(
 
         gt_k = padded_targets[:, step_k]  # [B]
 
-        # Build mask: valid if (a) gt is resolvable and (b) tactic expects this argument
         valid = gt_k >= 0
         for b_idx in range(batch_size):
             if tactic_arity_per_sample[b_idx] <= step_k:
                 valid[b_idx] = False
+            elif valid[b_idx]:
+                # Skip target if it was masked out by premise_mask
+                if torch.isneginf(arg_logits_k[b_idx, gt_k[b_idx]]):
+                    valid[b_idx] = False
 
         if not valid.any():
             continue

--- a/atp_lean_gnn/argument_selector.py
+++ b/atp_lean_gnn/argument_selector.py
@@ -83,7 +83,7 @@ class ArgumentSelector(nn.Module):
             )
 
         # Padded node embedding matrix
-        padded_keys = torch.zeros(batch_size, max_nodes, hidden_dim, device=device)
+        padded_keys = torch.zeros(batch_size, max_nodes, hidden_dim, device=device, dtype=node_embeddings.dtype)
         padded_keys[batch_index, offsets] = node_embeddings
 
         # Padded premise mask (False = invalid ⇒ will be masked to -inf)
@@ -347,7 +347,7 @@ def compute_combined_loss(
         if not valid.any():
             continue
 
-        step_loss = F.cross_entropy(arg_logits_k[valid], gt_k[valid])
+        step_loss = F.cross_entropy(arg_logits_k[valid].clamp(min=-1e4), gt_k[valid])
         arg_losses.append(step_loss)
 
     if arg_losses:

--- a/atp_lean_gnn/graph.py
+++ b/atp_lean_gnn/graph.py
@@ -154,6 +154,17 @@ def proof_state_to_dag(state: str | ProofState) -> DAGBuilder:
     return dag
 
 
+def lemma_statement_to_dag(statement: str) -> DAGBuilder:
+    """Build a DAG for a lemma statement treated as a goal-only proof state."""
+    dag = DAGBuilder()
+    parser = ExprParser(dag)
+
+    goal_expr_node = parser.parse(statement)
+    goal_node = dag.get_or_create("Goal", (goal_expr_node,))
+    dag.get_or_create("State", (goal_node,))
+    return dag
+
+
 def dag_to_dict(dag: DAGBuilder, metadata: dict[str, object] | None = None) -> dict[str, object]:
     child_counts = dag.incoming_counts()
     parent_uses = dag.outgoing_counts()

--- a/atp_lean_gnn/graph.py
+++ b/atp_lean_gnn/graph.py
@@ -14,9 +14,15 @@ class GraphNode:
     id: int
     label: str
     node_type: str
+    children: tuple[int, ...] = field(default_factory=tuple)
 
     def as_dict(self) -> dict[str, object]:
-        return {"id": self.id, "label": self.label, "node_type": self.node_type}
+        return {
+            "id": self.id,
+            "label": self.label,
+            "node_type": self.node_type,
+            "children": list(self.children),
+        }
 
 
 @dataclass(frozen=True)
@@ -77,7 +83,7 @@ class DAGBuilder:
             return self._memo[key]
 
         node_id = len(self.nodes)
-        self.nodes.append(GraphNode(node_id, label, _classify_label(label)))
+        self.nodes.append(GraphNode(node_id, label, _classify_label(label), children))
         for child_id in children:
             self.edges.append((child_id, node_id))
         self._memo[key] = node_id

--- a/atp_lean_gnn/inference.py
+++ b/atp_lean_gnn/inference.py
@@ -40,6 +40,7 @@ class InferencePipeline:
         tactic_vocab: dict[str, int],
         device: torch.device,
         k: int = 500,
+        lemma_corpus: dict[int, LemmaRecord] | None = None,
     ) -> None:
         self.model = model
         self.scorer = scorer
@@ -48,6 +49,7 @@ class InferencePipeline:
         self.tactic_vocab = tactic_vocab
         self.device = device
         self.k = k
+        self.lemma_corpus = lemma_corpus
 
         # Invert tactic vocab for decoding
         self.id_to_tactic = {idx: name for name, idx in tactic_vocab.items()}
@@ -65,6 +67,13 @@ class InferencePipeline:
         dag = proof_state_to_dag(state)
         data = dag_to_pyg(dag, self.node_vocab)
         
+        # Find the root State node for graph readout
+        try:
+            state_idx = next(i for i, n in enumerate(dag.nodes) if n.label == "State")
+        except StopIteration:
+            state_idx = 0
+        data.state_node_index = torch.tensor([state_idx], dtype=torch.long)
+        
         # Build premise mask for local candidates
         premise_mask = build_premise_mask(dag)
         data.premise_mask = torch.tensor(premise_mask, dtype=torch.bool)
@@ -77,7 +86,7 @@ class InferencePipeline:
         node_embeddings = self.model.backbone.encode_nodes(batch)
         state_emb = self.model.backbone.readout(node_embeddings, batch)
         
-        tactic_logits = self.model.tactic_head(state_emb)
+        tactic_logits = self.model.backbone.classifier(state_emb)
         tactic_id = tactic_logits.argmax(dim=-1).item()
         tactic_name = self.id_to_tactic.get(tactic_id, "<UNK>")
         
@@ -119,8 +128,10 @@ class InferencePipeline:
                 node = dag.nodes[cid]
                 arg_str = _resolve_local_node_name(node, dag)
             else:
-                lemma_record = self.lemma_index.get_lemma(cid)
-                arg_str = lemma_record.name if lemma_record else f"<lemma_{cid}>"
+                if self.lemma_corpus and cid in self.lemma_corpus:
+                    arg_str = self.lemma_corpus[cid].name
+                else:
+                    arg_str = f"<lemma_{cid}>"
                 
             arguments.append(arg_str)
             

--- a/atp_lean_gnn/inference.py
+++ b/atp_lean_gnn/inference.py
@@ -1,0 +1,127 @@
+"""Inference pipeline for end-to-end tactic prediction.
+
+This module provides the ``InferencePipeline`` which integrates graph conversion,
+tactic prediction, premise retrieval, and candidate scoring to produce a final
+tactic string.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch_geometric.data import Batch
+
+from .argument_selector import TacticWithArgsClassifier
+from .graph import DAGBuilder, GraphNode, proof_state_to_dag
+from .labels import get_tactic_arity
+from .lemma_index import LemmaIndex
+from .premise_pool import build_unified_pools
+from .premise_scoring import PremiseScorer
+from .pyg import build_premise_mask, dag_to_pyg
+from .state import ProofState, parse_state
+
+
+def _resolve_local_node_name(node: GraphNode, dag: DAGBuilder) -> str:
+    """Attempt to extract a readable hypothesis or variable name from a node."""
+    if node.label == "Hyp" and node.children:
+        name_node = dag.nodes[node.children[0]]
+        return name_node.label
+    return node.label
+
+
+class InferencePipeline:
+    """End-to-end tactic prediction pipeline."""
+
+    def __init__(
+        self,
+        model: TacticWithArgsClassifier,
+        scorer: PremiseScorer,
+        lemma_index: LemmaIndex,
+        node_vocab: dict[str, int],
+        tactic_vocab: dict[str, int],
+        device: torch.device,
+        k: int = 500,
+    ) -> None:
+        self.model = model
+        self.scorer = scorer
+        self.lemma_index = lemma_index
+        self.node_vocab = node_vocab
+        self.tactic_vocab = tactic_vocab
+        self.device = device
+        self.k = k
+
+        # Invert tactic vocab for decoding
+        self.id_to_tactic = {idx: name for name, idx in tactic_vocab.items()}
+
+        self.model.eval()
+        self.scorer.eval()
+
+    @torch.no_grad()
+    def predict_tactic(self, state_str: str) -> str:
+        """Predict a full tactic string given a Lean proof state."""
+        # Parse the raw state string into a ProofState
+        state = parse_state(state_str)
+        
+        # 1. Graph construction
+        dag = proof_state_to_dag(state)
+        data = dag_to_pyg(dag, self.node_vocab)
+        
+        # Build premise mask for local candidates
+        premise_mask = build_premise_mask(dag)
+        data.premise_mask = torch.tensor(premise_mask, dtype=torch.bool)
+        
+        # Move to device and batch
+        data = data.to(self.device)
+        batch = Batch.from_data_list([data])
+
+        # 2. Encode state and predict tactic
+        node_embeddings = self.model.backbone.encode_nodes(batch)
+        state_emb = self.model.backbone.readout(node_embeddings, batch)
+        
+        tactic_logits = self.model.tactic_head(state_emb)
+        tactic_id = tactic_logits.argmax(dim=-1).item()
+        tactic_name = self.id_to_tactic.get(tactic_id, "<UNK>")
+        
+        arity = get_tactic_arity(tactic_name)
+        if arity == 0:
+            return tactic_name
+            
+        # 3. Retrieve and Score Premises
+        # Convert integer tactic ID to a tensor for the embedding layer
+        tactic_id_tensor = torch.tensor([tactic_id], dtype=torch.long, device=self.device)
+        tactic_emb = self.model.tactic_embedding(tactic_id_tensor)
+        
+        pools = build_unified_pools(
+            state_emb,
+            node_embeddings,
+            batch.premise_mask,
+            batch.batch,
+            lemma_index=self.lemma_index,
+            k=self.k,
+        )
+        
+        pool = pools[0]
+        if not pool.candidate_ids:
+            return tactic_name
+            
+        # Score candidates
+        scores = self.scorer.score(state_emb.squeeze(0), tactic_emb.squeeze(0), pool.candidate_vectors)
+        
+        # Pick top `arity` arguments
+        sorted_indices = scores.argsort(descending=True)
+        top_indices = sorted_indices[:arity].tolist()
+        
+        arguments = []
+        for idx in top_indices:
+            source = pool.candidate_sources[idx]
+            cid = pool.candidate_ids[idx]
+            
+            if source == "local":
+                node = dag.nodes[cid]
+                arg_str = _resolve_local_node_name(node, dag)
+            else:
+                lemma_record = self.lemma_index.get_lemma(cid)
+                arg_str = lemma_record.name if lemma_record else f"<lemma_{cid}>"
+                
+            arguments.append(arg_str)
+            
+        return f"{tactic_name} {' '.join(arguments)}"

--- a/atp_lean_gnn/lemma_corpus.py
+++ b/atp_lean_gnn/lemma_corpus.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class LemmaRecord:
+    lemma_id: int
+    name: str
+    statement: str
+    namespace: str
+    module: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "lemma_id": self.lemma_id,
+            "name": self.name,
+            "statement": self.statement,
+            "namespace": self.namespace,
+            "module": self.module,
+        }
+
+
+def load_lemma_corpus(path: str | Path) -> list[LemmaRecord]:
+    corpus_path = Path(path)
+    if not corpus_path.exists():
+        raise FileNotFoundError(f"Lemma corpus not found at '{corpus_path}'.")
+
+    records: list[LemmaRecord] = []
+    with corpus_path.open("r", encoding="utf-8") as handle:
+        for line_index, line in enumerate(handle, start=1):
+            raw = line.strip()
+            if not raw:
+                continue
+            payload = json.loads(raw)
+            try:
+                lemma_id = int(payload["lemma_id"])
+                name = str(payload["name"]).strip()
+                statement = str(payload["statement"]).strip()
+            except KeyError as exc:
+                raise ValueError(
+                    f"Lemma corpus entry on line {line_index} is missing {exc.args[0]!r}."
+                ) from exc
+
+            if not name:
+                raise ValueError(f"Lemma corpus entry on line {line_index} has an empty name.")
+            if not statement:
+                raise ValueError(f"Lemma corpus entry on line {line_index} has an empty statement.")
+
+            records.append(
+                LemmaRecord(
+                    lemma_id=lemma_id,
+                    name=name,
+                    statement=statement,
+                    namespace=str(payload.get("namespace", "")),
+                    module=str(payload.get("module", "")),
+                )
+            )
+
+    if not records:
+        raise ValueError(f"Lemma corpus '{corpus_path}' is empty.")
+    return records
+
+
+def load_lemma_name_index(path: str | Path) -> dict[str, int]:
+    """Return a mapping from lemma name to lemma id.
+
+    The first occurrence of a lemma name wins if duplicates exist.
+    """
+    name_index: dict[str, int] = {}
+    for record in load_lemma_corpus(path):
+        if record.name not in name_index:
+            name_index[record.name] = record.lemma_id
+    return name_index
+
+
+def write_lemma_corpus(path: str | Path, records: list[LemmaRecord]) -> Path:
+    corpus_path = Path(path)
+    corpus_path.parent.mkdir(parents=True, exist_ok=True)
+    with corpus_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record.to_dict(), ensure_ascii=False, sort_keys=True))
+            handle.write("\n")
+    return corpus_path

--- a/atp_lean_gnn/lemma_index.py
+++ b/atp_lean_gnn/lemma_index.py
@@ -73,12 +73,12 @@ class LemmaIndex:
 
     def search(
         self,
-        goal_vecs: np.ndarray | "torch.Tensor",
+        state_vecs: np.ndarray | "torch.Tensor",
         *,
         k: int = 500,
     ) -> tuple[list[list[int]], np.ndarray, np.ndarray]:
         """Return (lemma_ids, lemma_vecs, scores) for each query."""
-        query = self._to_numpy(goal_vecs)
+        query = self._to_numpy(state_vecs)
         if self.normalize_queries:
             query = _normalize_rows(query)
 
@@ -88,15 +88,15 @@ class LemmaIndex:
         return lemma_ids, lemma_vecs, scores
 
     @staticmethod
-    def _to_numpy(goal_vecs: np.ndarray | "torch.Tensor") -> np.ndarray:
-        if isinstance(goal_vecs, np.ndarray):
-            array = goal_vecs
+    def _to_numpy(state_vecs: np.ndarray | "torch.Tensor") -> np.ndarray:
+        if isinstance(state_vecs, np.ndarray):
+            array = state_vecs
         else:
             import torch
 
-            if not torch.is_tensor(goal_vecs):
-                raise TypeError("goal_vecs must be a numpy array or torch Tensor.")
-            array = goal_vecs.detach().cpu().numpy()
+            if not torch.is_tensor(state_vecs):
+                raise TypeError("state_vecs must be a numpy array or torch Tensor.")
+            array = state_vecs.detach().cpu().numpy()
         if array.dtype != np.float32:
             array = array.astype(np.float32)
         return array

--- a/atp_lean_gnn/lemma_index.py
+++ b/atp_lean_gnn/lemma_index.py
@@ -83,8 +83,25 @@ class LemmaIndex:
             query = _normalize_rows(query)
 
         scores, indices = self.index.search(query, k)
-        lemma_ids = [[self.lemma_ids[int(idx)] for idx in row] for row in indices]
-        lemma_vecs = self.lemma_vectors[indices]
+        
+        num_lemmas = len(self.lemma_ids)
+        lemma_ids = [
+            [self.lemma_ids[int(idx)] if 0 <= int(idx) < num_lemmas else -1 for idx in row]
+            for row in indices
+        ]
+        
+        valid_mask = (indices >= 0) & (indices < num_lemmas)
+        safe_indices = np.where(valid_mask, indices, 0)
+        
+        if num_lemmas > 0:
+            lemma_vecs = self.lemma_vectors[safe_indices]
+            lemma_vecs[~valid_mask] = 0.0
+        else:
+            lemma_vecs = np.zeros(
+                (indices.shape[0], indices.shape[1], self.lemma_vectors.shape[1]),
+                dtype=self.lemma_vectors.dtype
+            )
+            
         return lemma_ids, lemma_vecs, scores
 
     @staticmethod

--- a/atp_lean_gnn/lemma_index.py
+++ b/atp_lean_gnn/lemma_index.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class LemmaIndexConfig:
+    index_dir: Path
+    k: int = 500
+    normalize_queries: bool = False
+
+
+class LemmaIndex:
+    """Load and query a FAISS index of precomputed lemma embeddings."""
+
+    def __init__(
+        self,
+        index: Any,
+        lemma_ids: list[int],
+        lemma_vectors: np.ndarray,
+        *,
+        normalize_queries: bool = False,
+    ) -> None:
+        self.index = index
+        self.lemma_ids = lemma_ids
+        self.lemma_vectors = lemma_vectors
+        self.normalize_queries = normalize_queries
+
+        if self.lemma_vectors.ndim != 2:
+            raise ValueError("lemma_vectors must be 2D (num_lemmas, dim).")
+        if len(self.lemma_ids) != self.lemma_vectors.shape[0]:
+            raise ValueError("lemma_ids length must match lemma_vectors rows.")
+        if hasattr(self.index, "d") and int(self.index.d) != int(self.lemma_vectors.shape[1]):
+            raise ValueError("FAISS index dimension does not match lemma_vectors.")
+
+    @classmethod
+    def load(
+        cls,
+        index_dir: str | Path,
+        *,
+        normalize_queries: bool = False,
+    ) -> "LemmaIndex":
+        import faiss
+
+        index_path = Path(index_dir) / "faiss.index"
+        vectors_path = Path(index_dir) / "lemma_vectors.npy"
+        ids_path = Path(index_dir) / "lemma_ids.json"
+
+        if not index_path.exists():
+            raise FileNotFoundError(f"FAISS index not found at '{index_path}'.")
+        if not vectors_path.exists():
+            raise FileNotFoundError(f"Lemma vectors not found at '{vectors_path}'.")
+        if not ids_path.exists():
+            raise FileNotFoundError(f"Lemma id map not found at '{ids_path}'.")
+
+        lemma_vectors = np.load(vectors_path)
+        lemma_ids = json.loads(ids_path.read_text(encoding="utf-8"))
+        if not isinstance(lemma_ids, list):
+            raise ValueError("lemma_ids.json must contain a JSON list of ids.")
+
+        index = faiss.read_index(str(index_path))
+        return cls(
+            index,
+            [int(x) for x in lemma_ids],
+            lemma_vectors,
+            normalize_queries=normalize_queries,
+        )
+
+    def search(
+        self,
+        goal_vecs: np.ndarray | "torch.Tensor",
+        *,
+        k: int = 500,
+    ) -> tuple[list[list[int]], np.ndarray, np.ndarray]:
+        """Return (lemma_ids, lemma_vecs, scores) for each query."""
+        query = self._to_numpy(goal_vecs)
+        if self.normalize_queries:
+            query = _normalize_rows(query)
+
+        scores, indices = self.index.search(query, k)
+        lemma_ids = [[self.lemma_ids[int(idx)] for idx in row] for row in indices]
+        lemma_vecs = self.lemma_vectors[indices]
+        return lemma_ids, lemma_vecs, scores
+
+    @staticmethod
+    def _to_numpy(goal_vecs: np.ndarray | "torch.Tensor") -> np.ndarray:
+        if isinstance(goal_vecs, np.ndarray):
+            array = goal_vecs
+        else:
+            import torch
+
+            if not torch.is_tensor(goal_vecs):
+                raise TypeError("goal_vecs must be a numpy array or torch Tensor.")
+            array = goal_vecs.detach().cpu().numpy()
+        if array.dtype != np.float32:
+            array = array.astype(np.float32)
+        return array
+
+
+def _normalize_rows(array: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(array, axis=1, keepdims=True)
+    norms = np.clip(norms, 1e-12, None)
+    return array / norms

--- a/atp_lean_gnn/premise_pool.py
+++ b/atp_lean_gnn/premise_pool.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+import torch
+from torch import Tensor
+
+
+class LemmaIndexLike(Protocol):
+    def search(
+        self,
+        goal_vecs: Tensor,
+        *,
+        k: int,
+    ) -> tuple[list[list[int]], np.ndarray, np.ndarray]:
+        ...
+
+
+@dataclass(frozen=True)
+class CandidatePool:
+    candidate_vectors: Tensor
+    candidate_sources: list[str]
+    candidate_ids: list[int]
+    local_node_ids: list[int]
+    lemma_ids: list[int]
+
+
+def build_unified_pools(
+    goal_vecs: Tensor,
+    node_embeddings: Tensor,
+    premise_mask: Tensor,
+    batch_index: Tensor,
+    *,
+    lemma_index: LemmaIndexLike,
+    k: int = 500,
+) -> list[CandidatePool]:
+    """Return per-graph candidate pools combining local and library premises."""
+    if goal_vecs.dim() != 2:
+        raise ValueError("goal_vecs must be [batch, hidden_dim].")
+    if node_embeddings.dim() != 2:
+        raise ValueError("node_embeddings must be [total_nodes, hidden_dim].")
+
+    device = node_embeddings.device
+    batch_size = int(goal_vecs.size(0))
+
+    lemma_ids_batch, lemma_vecs_batch, _scores = lemma_index.search(goal_vecs, k=k)
+    if len(lemma_ids_batch) != batch_size:
+        raise ValueError("lemma_index returned a batch size mismatch.")
+
+    lemma_vecs_batch = torch.from_numpy(lemma_vecs_batch).to(device=device)
+
+    pools: list[CandidatePool] = []
+    for b in range(batch_size):
+        local_mask = (batch_index == b) & premise_mask
+        local_ids = local_mask.nonzero(as_tuple=False).view(-1)
+        local_vecs = node_embeddings.index_select(0, local_ids)
+        local_id_list = [int(i) for i in local_ids.tolist()]
+
+        lemma_ids = [int(x) for x in lemma_ids_batch[b]]
+        lemma_vecs = lemma_vecs_batch[b]
+
+        if local_vecs.numel() == 0:
+            candidate_vectors = lemma_vecs
+            candidate_sources = ["lemma"] * len(lemma_ids)
+            candidate_ids = lemma_ids
+        elif lemma_vecs.numel() == 0:
+            candidate_vectors = local_vecs
+            candidate_sources = ["local"] * len(local_id_list)
+            candidate_ids = local_id_list
+        else:
+            candidate_vectors = torch.cat([local_vecs, lemma_vecs], dim=0)
+            candidate_sources = ["local"] * len(local_id_list) + ["lemma"] * len(lemma_ids)
+            candidate_ids = local_id_list + lemma_ids
+
+        pools.append(
+            CandidatePool(
+                candidate_vectors=candidate_vectors,
+                candidate_sources=candidate_sources,
+                candidate_ids=candidate_ids,
+                local_node_ids=local_id_list,
+                lemma_ids=lemma_ids,
+            )
+        )
+
+    return pools

--- a/atp_lean_gnn/premise_pool.py
+++ b/atp_lean_gnn/premise_pool.py
@@ -11,7 +11,7 @@ from torch import Tensor
 class LemmaIndexLike(Protocol):
     def search(
         self,
-        goal_vecs: Tensor,
+        state_vecs: Tensor,
         *,
         k: int,
     ) -> tuple[list[list[int]], np.ndarray, np.ndarray]:
@@ -28,7 +28,7 @@ class CandidatePool:
 
 
 def build_unified_pools(
-    goal_vecs: Tensor,
+    state_vecs: Tensor,
     node_embeddings: Tensor,
     premise_mask: Tensor,
     batch_index: Tensor,
@@ -37,15 +37,15 @@ def build_unified_pools(
     k: int = 500,
 ) -> list[CandidatePool]:
     """Return per-graph candidate pools combining local and library premises."""
-    if goal_vecs.dim() != 2:
-        raise ValueError("goal_vecs must be [batch, hidden_dim].")
+    if state_vecs.dim() != 2:
+        raise ValueError("state_vecs must be [batch, hidden_dim].")
     if node_embeddings.dim() != 2:
         raise ValueError("node_embeddings must be [total_nodes, hidden_dim].")
 
     device = node_embeddings.device
-    batch_size = int(goal_vecs.size(0))
+    batch_size = int(state_vecs.size(0))
 
-    lemma_ids_batch, lemma_vecs_batch, _scores = lemma_index.search(goal_vecs, k=k)
+    lemma_ids_batch, lemma_vecs_batch, _scores = lemma_index.search(state_vecs, k=k)
     if len(lemma_ids_batch) != batch_size:
         raise ValueError("lemma_index returned a batch size mismatch.")
 

--- a/atp_lean_gnn/premise_pool.py
+++ b/atp_lean_gnn/premise_pool.py
@@ -49,7 +49,7 @@ def build_unified_pools(
     if len(lemma_ids_batch) != batch_size:
         raise ValueError("lemma_index returned a batch size mismatch.")
 
-    lemma_vecs_batch = torch.from_numpy(lemma_vecs_batch).to(device=device)
+    lemma_vecs_batch = torch.from_numpy(lemma_vecs_batch).to(device=device, dtype=node_embeddings.dtype)
 
     pools: list[CandidatePool] = []
     for b in range(batch_size):

--- a/atp_lean_gnn/premise_scoring.py
+++ b/atp_lean_gnn/premise_scoring.py
@@ -31,6 +31,8 @@ class PremiseScorerConfig:
     scoring_mode: str = "dot"  # "dot" or "mlp"
     tactic_conditioning: str = "soft"  # "soft" or "hard"
     premise_loss_weight: float = 0.3
+    k: int = 500
+    rerank_size: int = 50
 
     def to_dict(self) -> dict[str, object]:
         return {

--- a/atp_lean_gnn/premise_scoring.py
+++ b/atp_lean_gnn/premise_scoring.py
@@ -1,0 +1,296 @@
+"""Premise scoring head for unified candidate pools.
+
+This module provides ``PremiseScorer``, a tactic-conditioned scoring module
+that scores mixed candidate pools (local hypotheses + library lemmas) against
+a goal embedding.  Two scoring modes are supported:
+
+- **dot**: Scaled dot-product between a projected query and candidate vectors.
+- **mlp**: A two-layer MLP that takes the concatenation of query and candidate.
+
+The ``compute_premise_ranking_loss`` function computes cross-entropy ranking
+loss over the unified candidate pool for each sample in a batch.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+from .premise_pool import CandidatePool
+
+
+@dataclass(frozen=True)
+class PremiseScorerConfig:
+    """Configuration for the premise scoring head."""
+
+    hidden_dim: int = 128
+    scoring_mode: str = "dot"  # "dot" or "mlp"
+    tactic_conditioning: str = "soft"  # "soft" or "hard"
+    premise_loss_weight: float = 0.3
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "hidden_dim": self.hidden_dim,
+            "scoring_mode": self.scoring_mode,
+            "tactic_conditioning": self.tactic_conditioning,
+            "premise_loss_weight": self.premise_loss_weight,
+        }
+
+
+class PremiseScorer(nn.Module):
+    """Score unified candidate premises with tactic-conditioned queries.
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Dimensionality of goal, tactic, and candidate embeddings.
+    mode : str
+        Scoring mode — ``"dot"`` for scaled dot-product, ``"mlp"`` for a
+        learned two-layer scorer.
+    """
+
+    def __init__(self, hidden_dim: int, *, mode: str = "dot") -> None:
+        super().__init__()
+
+        if mode not in {"dot", "mlp"}:
+            raise ValueError(f"Unsupported scoring mode '{mode}'. Use 'dot' or 'mlp'.")
+
+        self.mode = mode
+        self.hidden_dim = hidden_dim
+
+        # Project [goal_vec; tactic_emb] → hidden_dim
+        self.query_proj = nn.Linear(hidden_dim * 2, hidden_dim)
+
+        if mode == "mlp":
+            self.scorer = nn.Sequential(
+                nn.Linear(hidden_dim * 2, hidden_dim),
+                nn.ReLU(),
+                nn.Linear(hidden_dim, 1),
+            )
+        else:
+            self.scorer = None
+
+        self._scale = 1.0 / math.sqrt(hidden_dim)
+
+    def score(
+        self,
+        goal_vec: Tensor,
+        tactic_emb: Tensor,
+        candidate_vectors: Tensor,
+    ) -> Tensor:
+        """Score each candidate against the tactic-conditioned goal.
+
+        Parameters
+        ----------
+        goal_vec : Tensor
+            Goal embedding, shape ``[H]`` or ``[1, H]``.
+        tactic_emb : Tensor
+            Tactic embedding, shape ``[H]`` or ``[1, H]``.
+        candidate_vectors : Tensor
+            Candidate embeddings, shape ``[C, H]``.
+
+        Returns
+        -------
+        Tensor
+            Scores, shape ``[C]``.
+        """
+        # Flatten to [H]
+        goal = goal_vec.view(-1)
+        tactic = tactic_emb.view(-1)
+
+        # Project the conditioned query
+        query = self.query_proj(torch.cat([goal, tactic], dim=0))  # [H]
+
+        if self.mode == "dot":
+            # Scaled dot-product
+            scores = (candidate_vectors @ query) * self._scale  # [C]
+        else:
+            # MLP: concat query with each candidate and score
+            num_candidates = candidate_vectors.size(0)
+            query_expanded = query.unsqueeze(0).expand(num_candidates, -1)  # [C, H]
+            combined = torch.cat([query_expanded, candidate_vectors], dim=1)  # [C, 2H]
+            scores = self.scorer(combined).squeeze(-1)  # [C]
+
+        return scores
+
+    def forward(
+        self,
+        goal_vecs: Tensor,
+        tactic_embs: Tensor,
+        pools: list[CandidatePool],
+    ) -> list[Tensor]:
+        """Score all candidate pools in a batch.
+
+        Parameters
+        ----------
+        goal_vecs : Tensor
+            Goal embeddings, shape ``[B, H]``.
+        tactic_embs : Tensor
+            Tactic embeddings, shape ``[B, H]``.
+        pools : list[CandidatePool]
+            One pool per sample in the batch.
+
+        Returns
+        -------
+        list[Tensor]
+            Per-sample score tensors, each of shape ``[C_i]``.
+        """
+        batch_size = goal_vecs.size(0)
+        if len(pools) != batch_size:
+            raise ValueError(
+                f"Number of pools ({len(pools)}) does not match "
+                f"batch size ({batch_size})."
+            )
+
+        all_scores: list[Tensor] = []
+        for b in range(batch_size):
+            scores = self.score(
+                goal_vecs[b],
+                tactic_embs[b],
+                pools[b].candidate_vectors,
+            )
+            all_scores.append(scores)
+
+        return all_scores
+
+
+def _find_target_index_in_pool(
+    pool: CandidatePool,
+    *,
+    arg_node_indices: list[int],
+    arg_lemma_ids: list[int],
+) -> int:
+    """Find the index of the true premise in the candidate pool.
+
+    Priority:
+    1. If any ``arg_node_indices`` entry is >= 0 and matches a local candidate,
+       return the pool position of that local node.
+    2. If any ``arg_lemma_ids`` entry is >= 0 and matches a library candidate,
+       return the pool position of that lemma.
+    3. Return -1 if no match is found.
+    """
+    # Try local matches first
+    for node_id in arg_node_indices:
+        if node_id < 0:
+            continue
+        for pool_idx, (source, cid) in enumerate(
+            zip(pool.candidate_sources, pool.candidate_ids)
+        ):
+            if source == "local" and cid == node_id:
+                return pool_idx
+
+    # Try library matches
+    for lemma_id in arg_lemma_ids:
+        if lemma_id < 0:
+            continue
+        for pool_idx, (source, cid) in enumerate(
+            zip(pool.candidate_sources, pool.candidate_ids)
+        ):
+            if source == "lemma" and cid == lemma_id:
+                return pool_idx
+
+    return -1
+
+
+def compute_premise_ranking_loss(
+    score_list: list[Tensor],
+    pools: list[CandidatePool],
+    arg_node_indices: Tensor,
+    arg_lemma_ids: Tensor,
+) -> tuple[Tensor, dict[str, float]]:
+    """Cross-entropy ranking loss over unified candidate pools, with metrics.
+
+    For each sample in the batch, we find the true premise in the candidate
+    pool and compute a cross-entropy loss against the scored candidates.
+    Also tracks retrieval and reranking metrics.
+
+    Parameters
+    ----------
+    score_list : list[Tensor]
+        Per-sample score tensors from ``PremiseScorer.forward()``.
+    pools : list[CandidatePool]
+        One pool per sample.
+    arg_node_indices : Tensor
+        Ground-truth local node indices, shape ``[B, max_args]``, -1 for invalid.
+    arg_lemma_ids : Tensor
+        Ground-truth lemma IDs, shape ``[B, max_args]``, -1 for invalid.
+
+    Returns
+    -------
+    loss : Tensor
+        Scalar ranking loss (averaged over valid samples).
+    metrics : dict
+        ``"premise_loss"``, ``"valid_samples"``, ``"total_samples"``,
+        ``"target_present_count"``, ``"top1_correct"``, ``"top5_correct"``,
+        ``"mrr_sum"``.
+    """
+    batch_size = len(score_list)
+    device = score_list[0].device if score_list else torch.device("cpu")
+
+    losses: list[Tensor] = []
+    valid_count = 0
+    target_present_count = 0
+    top1_correct = 0
+    top5_correct = 0
+    mrr_sum = 0.0
+
+    for b in range(batch_size):
+        scores = score_list[b]  # [C_b]
+        pool = pools[b]
+
+        # Get ground-truth node/lemma IDs for this sample
+        b_node_ids = arg_node_indices[b].tolist() if arg_node_indices.dim() > 1 else [int(arg_node_indices[b].item())]
+        b_lemma_ids = arg_lemma_ids[b].tolist() if arg_lemma_ids.dim() > 1 else [int(arg_lemma_ids[b].item())]
+
+        has_target = any(i >= 0 for i in b_node_ids) or any(i >= 0 for i in b_lemma_ids)
+        if not has_target:
+            continue
+
+        target_present_count += 1
+
+        target_idx = _find_target_index_in_pool(
+            pool,
+            arg_node_indices=b_node_ids,
+            arg_lemma_ids=b_lemma_ids,
+        )
+
+        if target_idx < 0:
+            # Target exists but wasn't retrieved in the pool — skip loss
+            continue
+
+        target = torch.tensor(target_idx, dtype=torch.long, device=device)
+        loss = F.cross_entropy(scores.unsqueeze(0), target.unsqueeze(0))
+        losses.append(loss)
+        valid_count += 1
+
+        # Reranking metrics
+        # Sort scores in descending order to find the rank of the true target
+        sorted_indices = scores.argsort(descending=True).tolist()
+        rank = sorted_indices.index(target_idx) + 1  # 1-indexed
+
+        if rank == 1:
+            top1_correct += 1
+        if rank <= 5:
+            top5_correct += 1
+        mrr_sum += 1.0 / rank
+
+    if losses:
+        total_loss = torch.stack(losses).mean()
+    else:
+        total_loss = torch.tensor(0.0, device=device, requires_grad=True)
+
+    metrics = {
+        "premise_loss": float(total_loss.item()),
+        "valid_samples": valid_count,
+        "total_samples": batch_size,
+        "target_present_count": target_present_count,
+        "top1_correct": top1_correct,
+        "top5_correct": top5_correct,
+        "mrr_sum": mrr_sum,
+    }
+
+    return total_loss, metrics

--- a/atp_lean_gnn/premise_scoring.py
+++ b/atp_lean_gnn/premise_scoring.py
@@ -31,7 +31,7 @@ class PremiseScorerConfig:
     scoring_mode: str = "dot"  # "dot" or "mlp"
     tactic_conditioning: str = "soft"  # "soft" or "hard"
     premise_loss_weight: float = 0.3
-    k: int = 500
+    k: int = 200
     rerank_size: int = 50
 
     def to_dict(self) -> dict[str, object]:
@@ -66,6 +66,7 @@ class PremiseScorer(nn.Module):
 
         # Project [goal_vec; tactic_emb] → hidden_dim
         self.query_proj = nn.Linear(hidden_dim * 2, hidden_dim)
+        self.key_proj = nn.Linear(hidden_dim, hidden_dim)
 
         if mode == "mlp":
             self.scorer = nn.Sequential(
@@ -104,8 +105,8 @@ class PremiseScorer(nn.Module):
         goal = goal_vec.view(-1)
         tactic = tactic_emb.view(-1)
 
-        # Project the conditioned query
-        query = self.query_proj(torch.cat([goal, tactic], dim=0))  # [H]
+        query = self.query_proj(torch.cat([goal, tactic], dim=0))
+        candidate_vectors = self.key_proj(candidate_vectors)
 
         if self.mode == "dot":
             # Scaled dot-product

--- a/atp_lean_gnn/premise_training.py
+++ b/atp_lean_gnn/premise_training.py
@@ -112,6 +112,7 @@ def train_one_epoch_with_premises(
 ) -> dict[str, float | int]:
     """Train one epoch with combined tactic + argument + premise ranking loss."""
     model.train()
+    model.backbone.eval()  # frozen backbone stays in eval mode
     scorer.train()
 
     total_tactic_loss = 0.0
@@ -159,9 +160,12 @@ def train_one_epoch_with_premises(
                 unknown_tactic_id=unknown_tactic_id,
             )
 
-            # Get embeddings for premise scoring
-            node_embeddings = model.backbone.encode_nodes(batch)
-            state_emb = model.backbone.readout(node_embeddings, batch)
+            # Recompute embeddings (detached) for the premise scoring branch
+            with torch.no_grad():
+                node_embeddings = model.backbone.encode_nodes(batch)
+                state_emb = model.backbone.readout(node_embeddings, batch)
+            node_embeddings = node_embeddings.detach()
+            state_emb = state_emb.detach()
 
             # Get tactic embeddings
             tactic_emb = model.tactic_embedding(targets)
@@ -197,10 +201,8 @@ def train_one_epoch_with_premises(
 
         grad_scaler.scale(total_loss).backward()
         grad_scaler.unscale_(optimizer)
-        torch.nn.utils.clip_grad_norm_(
-            list(model.parameters()) + list(scorer.parameters()),
-            grad_clip,
-        )
+        trainable_params = [p for p in list(model.parameters()) + list(scorer.parameters()) if p.requires_grad]
+        torch.nn.utils.clip_grad_norm_(trainable_params, grad_clip)
         grad_scaler.step(optimizer)
         grad_scaler.update()
 
@@ -304,8 +306,9 @@ def evaluate_model_with_premises(
                 unknown_tactic_id=unknown_tactic_id,
             )
 
-            node_embeddings = model.backbone.encode_nodes(batch)
-            state_emb = model.backbone.readout(node_embeddings, batch)
+            with torch.no_grad():
+                node_embeddings = model.backbone.encode_nodes(batch)
+                state_emb = model.backbone.readout(node_embeddings, batch)
             tactic_ids = tactic_logits.argmax(dim=1)
             tactic_emb = model.tactic_embedding(tactic_ids)
             premise_mask = batch.premise_mask.to(

--- a/atp_lean_gnn/premise_training.py
+++ b/atp_lean_gnn/premise_training.py
@@ -1,0 +1,383 @@
+"""Premise-aware training and evaluation loops.
+
+These extend the argument-aware loops in ``argument_training.py`` by adding
+premise ranking loss from the unified candidate pool.
+"""
+
+from __future__ import annotations
+
+import time
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.optim import AdamW
+from torch_geometric.loader import DataLoader
+
+from .argument_selector import TacticWithArgsClassifier, compute_combined_loss
+from .labels import get_tactic_arity
+from .lemma_index import LemmaIndex
+from .premise_pool import build_unified_pools
+from .premise_scoring import PremiseScorer, compute_premise_ranking_loss
+from .reporting import console_print
+
+
+def _format_elapsed(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, remaining_seconds = divmod(seconds, 60)
+    return f"{int(minutes)}m {remaining_seconds:.0f}s"
+
+
+def _should_log_batch(
+    batch_index: int, total_batches: int, *, log_every_batches: int
+) -> bool:
+    return (
+        batch_index == 1
+        or batch_index == total_batches
+        or batch_index % log_every_batches == 0
+    )
+
+
+def _extract_tactic_names(batch) -> list[str]:
+    """Extract per-sample tactic family names from a PyG Batch."""
+    if hasattr(batch, "tactic_name"):
+        names = batch.tactic_name
+        if isinstance(names, (list, tuple)):
+            return [str(n) for n in names]
+        return [str(names)]
+    batch_size = int(batch.y.size(0)) if hasattr(batch, "y") else 1
+    return [""] * batch_size
+
+
+def _extract_arg_targets(
+    batch, max_args: int, device: torch.device
+) -> torch.Tensor:
+    """Extract ground-truth argument node indices [B, max_args], padded with -1."""
+    if hasattr(batch, "arg_node_indices"):
+        targets = batch.arg_node_indices.to(device=device, dtype=torch.long)
+        if targets.dim() == 1:
+            targets = targets.unsqueeze(0)
+        b, current_cols = targets.shape
+        if current_cols < max_args:
+            padding = torch.full(
+                (b, max_args - current_cols), -1, dtype=torch.long, device=device
+            )
+            targets = torch.cat([targets, padding], dim=1)
+        elif current_cols > max_args:
+            targets = targets[:, :max_args]
+        return targets
+    batch_size = int(batch.y.size(0)) if hasattr(batch, "y") else 1
+    return torch.full((batch_size, max_args), -1, dtype=torch.long, device=device)
+
+
+def _extract_arg_lemma_ids(
+    batch, max_args: int, device: torch.device
+) -> torch.Tensor:
+    """Extract ground-truth lemma IDs [B, max_args], padded with -1."""
+    if hasattr(batch, "arg_lemma_ids"):
+        targets = batch.arg_lemma_ids.to(device=device, dtype=torch.long)
+        if targets.dim() == 1:
+            targets = targets.unsqueeze(0)
+        b, current_cols = targets.shape
+        if current_cols < max_args:
+            padding = torch.full(
+                (b, max_args - current_cols), -1, dtype=torch.long, device=device
+            )
+            targets = torch.cat([targets, padding], dim=1)
+        elif current_cols > max_args:
+            targets = targets[:, :max_args]
+        return targets
+    batch_size = int(batch.y.size(0)) if hasattr(batch, "y") else 1
+    return torch.full((batch_size, max_args), -1, dtype=torch.long, device=device)
+
+
+def train_one_epoch_with_premises(
+    model: TacticWithArgsClassifier,
+    scorer: PremiseScorer,
+    loader: DataLoader,
+    lemma_index: LemmaIndex,
+    *,
+    optimizer: AdamW,
+    grad_scaler,
+    device: torch.device,
+    grad_clip: float,
+    unknown_tactic_id: int,
+    arg_loss_weight: float,
+    premise_loss_weight: float,
+    k: int = 500,
+    epoch: int,
+    total_epochs: int,
+    log_every_batches: int,
+    use_amp: bool,
+    pin_memory: bool,
+) -> dict[str, float | int]:
+    """Train one epoch with combined tactic + argument + premise ranking loss."""
+    model.train()
+    scorer.train()
+
+    total_tactic_loss = 0.0
+    total_arg_loss = 0.0
+    total_premise_loss = 0.0
+    total_combined_loss = 0.0
+    total_examples = 0
+    total_batches = len(loader)
+    start_time = time.perf_counter()
+
+    console_print(
+        f"  Starting epoch {epoch:02d}/{total_epochs:02d} "
+        f"with {total_batches} train batches (premise-aware)..."
+    )
+
+    for batch_index, batch in enumerate(loader, start=1):
+        batch = batch.to(
+            device, non_blocking=(device.type == "cuda" and pin_memory)
+        )
+        targets = batch.y.view(-1)
+        tactic_names = _extract_tactic_names(batch)
+        arg_targets = _extract_arg_targets(batch, model.max_args, device)
+        arg_lemma_targets = _extract_arg_lemma_ids(batch, model.max_args, device)
+        tactic_arities = [get_tactic_arity(n) for n in tactic_names]
+
+        optimizer.zero_grad(set_to_none=True)
+
+        with torch.amp.autocast(device_type=device.type, enabled=use_amp):
+            # Forward pass through model
+            tactic_logits, arg_logits_list = model(
+                batch,
+                teacher_tactic_ids=targets,
+                tactic_names=tactic_names,
+            )
+
+            # Combined tactic + argument loss
+            ta_loss, ta_metrics = compute_combined_loss(
+                tactic_logits,
+                arg_logits_list,
+                targets,
+                arg_targets,
+                batch.batch,
+                tactic_arity_per_sample=tactic_arities,
+                arg_loss_weight=arg_loss_weight,
+                unknown_tactic_id=unknown_tactic_id,
+            )
+
+            # Get embeddings for premise scoring
+            node_embeddings = model.backbone.encode_nodes(batch)
+            state_emb = model.backbone.readout(node_embeddings, batch)
+
+            # Get tactic embeddings
+            tactic_emb = model.tactic_embedding(targets)
+
+            # Build premise mask
+            premise_mask = batch.premise_mask.to(
+                dtype=torch.bool, device=device
+            )
+
+            # Build unified candidate pools
+            pools = build_unified_pools(
+                state_emb,
+                node_embeddings,
+                premise_mask,
+                batch.batch,
+                lemma_index=lemma_index,
+                k=k,
+            )
+
+            # Score candidates
+            score_list = scorer(state_emb, tactic_emb, pools)
+
+            # Premise ranking loss
+            p_loss, p_metrics = compute_premise_ranking_loss(
+                score_list,
+                pools,
+                arg_targets,
+                arg_lemma_targets,
+            )
+
+            # Total loss
+            total_loss = ta_loss + premise_loss_weight * p_loss
+
+        grad_scaler.scale(total_loss).backward()
+        grad_scaler.unscale_(optimizer)
+        torch.nn.utils.clip_grad_norm_(
+            list(model.parameters()) + list(scorer.parameters()),
+            grad_clip,
+        )
+        grad_scaler.step(optimizer)
+        grad_scaler.update()
+
+        batch_size = int(targets.numel())
+        total_tactic_loss += ta_metrics["tactic_loss"] * batch_size
+        total_arg_loss += ta_metrics["arg_loss"] * batch_size
+        total_premise_loss += p_metrics["premise_loss"] * batch_size
+        total_combined_loss += float(total_loss.item()) * batch_size
+        total_examples += batch_size
+
+        if _should_log_batch(
+            batch_index, total_batches, log_every_batches=log_every_batches
+        ):
+            elapsed = _format_elapsed(time.perf_counter() - start_time)
+            n = max(total_examples, 1)
+            console_print(
+                f"    train batch {batch_index:>5}/{total_batches} | "
+                f"seen={total_examples} | "
+                f"tac={total_tactic_loss / n:.4f} "
+                f"arg={total_arg_loss / n:.4f} "
+                f"prem={total_premise_loss / n:.4f} | "
+                f"elapsed={elapsed}"
+            )
+
+    n = max(total_examples, 1)
+    return {
+        "tactic_loss": total_tactic_loss / n,
+        "arg_loss": total_arg_loss / n,
+        "premise_loss": total_premise_loss / n,
+        "combined_loss": total_combined_loss / n,
+        "example_count": total_examples,
+    }
+
+
+@torch.no_grad()
+def evaluate_model_with_premises(
+    model: TacticWithArgsClassifier,
+    scorer: PremiseScorer,
+    loader: DataLoader,
+    lemma_index: LemmaIndex,
+    *,
+    device: torch.device,
+    unknown_tactic_id: int,
+    arg_loss_weight: float,
+    premise_loss_weight: float,
+    k: int = 500,
+    split_name: str | None = None,
+    log_every_batches: int | None = None,
+    use_amp: bool = False,
+    pin_memory: bool = False,
+) -> dict[str, float | int]:
+    """Evaluate model with combined tactic + argument + premise metrics."""
+    model.eval()
+    scorer.eval()
+
+    total_tactic_loss = 0.0
+    total_arg_loss = 0.0
+    total_premise_loss = 0.0
+    total_combined_loss = 0.0
+    top1_correct = 0
+    known_count = 0
+
+    premise_valid = 0
+    premise_target_present = 0
+    premise_top1_correct = 0
+    premise_top5_correct = 0
+    premise_mrr_sum = 0.0
+
+    total_count = 0
+    total_batches = len(loader)
+    start_time = time.perf_counter()
+
+    if split_name is not None:
+        console_print(
+            f"  Evaluating {split_name} split "
+            f"({total_batches} batches, premise-aware)..."
+        )
+
+    for batch_index, batch in enumerate(loader, start=1):
+        batch = batch.to(
+            device, non_blocking=(device.type == "cuda" and pin_memory)
+        )
+        targets = batch.y.view(-1)
+        tactic_names = _extract_tactic_names(batch)
+        arg_targets = _extract_arg_targets(batch, model.max_args, device)
+        arg_lemma_targets = _extract_arg_lemma_ids(batch, model.max_args, device)
+        tactic_arities = [get_tactic_arity(n) for n in tactic_names]
+
+        with torch.amp.autocast(device_type=device.type, enabled=use_amp):
+            tactic_logits, arg_logits_list = model(
+                batch, tactic_names=tactic_names
+            )
+            ta_loss, ta_metrics = compute_combined_loss(
+                tactic_logits,
+                arg_logits_list,
+                targets,
+                arg_targets,
+                batch.batch,
+                tactic_arity_per_sample=tactic_arities,
+                arg_loss_weight=arg_loss_weight,
+                unknown_tactic_id=unknown_tactic_id,
+            )
+
+            node_embeddings = model.backbone.encode_nodes(batch)
+            state_emb = model.backbone.readout(node_embeddings, batch)
+            tactic_ids = tactic_logits.argmax(dim=1)
+            tactic_emb = model.tactic_embedding(tactic_ids)
+            premise_mask = batch.premise_mask.to(
+                dtype=torch.bool, device=device
+            )
+
+            pools = build_unified_pools(
+                state_emb,
+                node_embeddings,
+                premise_mask,
+                batch.batch,
+                lemma_index=lemma_index,
+                k=k,
+            )
+            score_list = scorer(state_emb, tactic_emb, pools)
+            p_loss, p_metrics = compute_premise_ranking_loss(
+                score_list, pools, arg_targets, arg_lemma_targets
+            )
+
+        bs = int(targets.numel())
+        total_tactic_loss += ta_metrics["tactic_loss"] * bs
+        total_arg_loss += ta_metrics["arg_loss"] * bs
+        total_premise_loss += p_metrics["premise_loss"] * bs
+        total_combined_loss += (
+            ta_metrics["total_loss"]
+            + premise_loss_weight * p_metrics["premise_loss"]
+        ) * bs
+        premise_valid += p_metrics["valid_samples"]
+        premise_target_present += p_metrics["target_present_count"]
+        premise_top1_correct += p_metrics["top1_correct"]
+        premise_top5_correct += p_metrics["top5_correct"]
+        premise_mrr_sum += p_metrics["mrr_sum"]
+
+        # Tactic top-1 accuracy (excluding UNK)
+        known_mask = targets != unknown_tactic_id
+        kc = int(known_mask.sum().item())
+        if kc > 0:
+            preds = tactic_logits[known_mask].argmax(dim=1)
+            top1_correct += int((preds == targets[known_mask]).sum().item())
+        known_count += kc
+        total_count += bs
+
+        if (
+            split_name is not None
+            and log_every_batches is not None
+            and _should_log_batch(
+                batch_index,
+                total_batches,
+                log_every_batches=log_every_batches,
+            )
+        ):
+            elapsed = _format_elapsed(time.perf_counter() - start_time)
+            console_print(
+                f"    {split_name} batch {batch_index:>5}/{total_batches} | "
+                f"known={known_count} | elapsed={elapsed}"
+            )
+
+    n = max(total_count, 1)
+    return {
+        "tactic_loss": total_tactic_loss / n,
+        "arg_loss": total_arg_loss / n,
+        "premise_loss": total_premise_loss / n,
+        "combined_loss": total_combined_loss / n,
+        "tactic_top1_accuracy": top1_correct / max(known_count, 1),
+        "premise_recall": premise_valid / max(premise_target_present, 1),
+        "premise_mrr": premise_mrr_sum / max(premise_valid, 1),
+        "premise_top1_accuracy": premise_top1_correct / max(premise_valid, 1),
+        "premise_top5_accuracy": premise_top5_correct / max(premise_valid, 1),
+        "known_label_count": known_count,
+        "premise_target_present_count": premise_target_present,
+        "premise_valid_count": premise_valid,
+        "evaluated_count": total_count,
+    }

--- a/atp_lean_gnn/premise_training.py
+++ b/atp_lean_gnn/premise_training.py
@@ -54,42 +54,40 @@ def _extract_arg_targets(
     batch, max_args: int, device: torch.device
 ) -> torch.Tensor:
     """Extract ground-truth argument node indices [B, max_args], padded with -1."""
-    if hasattr(batch, "arg_node_indices"):
-        targets = batch.arg_node_indices.to(device=device, dtype=torch.long)
-        if targets.dim() == 1:
-            targets = targets.unsqueeze(0)
-        b, current_cols = targets.shape
-        if current_cols < max_args:
-            padding = torch.full(
-                (b, max_args - current_cols), -1, dtype=torch.long, device=device
-            )
-            targets = torch.cat([targets, padding], dim=1)
-        elif current_cols > max_args:
-            targets = targets[:, :max_args]
-        return targets
     batch_size = int(batch.y.size(0)) if hasattr(batch, "y") else 1
-    return torch.full((batch_size, max_args), -1, dtype=torch.long, device=device)
+    targets = torch.full((batch_size, max_args), -1, dtype=torch.long, device=device)
+    
+    if hasattr(batch, "arg_node_indices") and hasattr(batch, "arg_count"):
+        flat_targets = batch.arg_node_indices.to(device=device, dtype=torch.long)
+        counts = batch.arg_count.tolist()
+        offset = 0
+        for i, count in enumerate(counts):
+            n_copy = min(count, max_args)
+            if n_copy > 0:
+                targets[i, :n_copy] = flat_targets[offset : offset + n_copy]
+            offset += count
+            
+    return targets
 
 
 def _extract_arg_lemma_ids(
     batch, max_args: int, device: torch.device
 ) -> torch.Tensor:
     """Extract ground-truth lemma IDs [B, max_args], padded with -1."""
-    if hasattr(batch, "arg_lemma_ids"):
-        targets = batch.arg_lemma_ids.to(device=device, dtype=torch.long)
-        if targets.dim() == 1:
-            targets = targets.unsqueeze(0)
-        b, current_cols = targets.shape
-        if current_cols < max_args:
-            padding = torch.full(
-                (b, max_args - current_cols), -1, dtype=torch.long, device=device
-            )
-            targets = torch.cat([targets, padding], dim=1)
-        elif current_cols > max_args:
-            targets = targets[:, :max_args]
-        return targets
     batch_size = int(batch.y.size(0)) if hasattr(batch, "y") else 1
-    return torch.full((batch_size, max_args), -1, dtype=torch.long, device=device)
+    targets = torch.full((batch_size, max_args), -1, dtype=torch.long, device=device)
+    
+    if hasattr(batch, "arg_lemma_ids") and hasattr(batch, "arg_count"):
+        flat_targets = batch.arg_lemma_ids.to(device=device, dtype=torch.long)
+        counts = batch.arg_count.tolist()
+        offset = 0
+        for i, count in enumerate(counts):
+            n_copy = min(count, max_args)
+            if n_copy > 0:
+                targets[i, :n_copy] = flat_targets[offset : offset + n_copy]
+            offset += count
+            
+    return targets
 
 
 def train_one_epoch_with_premises(

--- a/atp_lean_gnn/preprocess.py
+++ b/atp_lean_gnn/preprocess.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+if __package__ in {None, ""}:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
 
 from .cache import (
     SplitReport,
@@ -21,6 +29,7 @@ from .cache import (
 from .dataset import DATASET_NAME, canonicalize_split_name, iter_dataset_rows
 from .preparation import prepare_example
 from .labels import build_tactic_vocab, encode_tactic_name
+from .lemma_corpus import load_lemma_name_index
 from .pyg import build_vocab_from_labels, dag_to_pyg
 from .reporting import console_print
 
@@ -34,6 +43,7 @@ class PreprocessConfig:
     splits: tuple[str, ...] = ("train", "val", "test")
     output_root: Path = DEFAULT_OUTPUT_ROOT
     sample_per_split: int | None = None
+    lemma_corpus_path: Path | None = None
     force: bool = False
 
 
@@ -109,6 +119,17 @@ def _resolve_arg_node_indices(dag, arg_tokens: list[str]) -> list[int]:
     return [label_to_id.get(token, -1) for token in arg_tokens]
 
 
+def _resolve_arg_lemma_ids(
+    arg_tokens: list[str],
+    lemma_name_index: dict[str, int] | None,
+) -> list[int]:
+    if not arg_tokens:
+        return []
+    if lemma_name_index is None:
+        return [-1 for _ in arg_tokens]
+    return [lemma_name_index.get(token, -1) for token in arg_tokens]
+
+
 def process_split(
     *,
     dataset_name: str,
@@ -117,6 +138,7 @@ def process_split(
     output_root: Path,
     node_vocab: dict[str, int],
     tactic_vocab: dict[str, int],
+    lemma_name_index: dict[str, int] | None,
 ) -> tuple[SplitReport, dict[str, object]]:
     import torch
 
@@ -171,7 +193,12 @@ def process_split(
 
         _, arg_tokens = parse_tactic_arguments(example.row.tactic)
         arg_indices = _resolve_arg_node_indices(example.dag, arg_tokens)
+        arg_lemma_ids = _resolve_arg_lemma_ids(arg_tokens, lemma_name_index)
+        for idx, node_id in enumerate(arg_indices):
+            if node_id >= 0 and idx < len(arg_lemma_ids):
+                arg_lemma_ids[idx] = -1
         data.arg_node_indices = torch.tensor(arg_indices, dtype=torch.long) if arg_indices else torch.tensor([], dtype=torch.long)
+        data.arg_lemma_ids = torch.tensor(arg_lemma_ids, dtype=torch.long) if arg_lemma_ids else torch.tensor([], dtype=torch.long)
         data.arg_count = len(arg_indices)
         # --------------------------------------------------------------
 
@@ -216,6 +243,10 @@ def run_preprocessing(config: PreprocessConfig) -> dict[str, object]:
         f"success={train_scan.success_count}, failure={train_scan.failure_count}"
     )
 
+    lemma_name_index = None
+    if config.lemma_corpus_path is not None:
+        lemma_name_index = load_lemma_name_index(config.lemma_corpus_path)
+
     prepare_output_root(output_root, splits=list(config.splits), force=config.force)
     write_vocab(output_root, name="node_vocab.json", vocab=node_vocab)
     write_vocab(output_root, name="tactic_vocab.json", vocab=tactic_vocab)
@@ -231,6 +262,7 @@ def run_preprocessing(config: PreprocessConfig) -> dict[str, object]:
             output_root=output_root,
             node_vocab=node_vocab,
             tactic_vocab=tactic_vocab,
+            lemma_name_index=lemma_name_index,
         )
         split_reports[split] = report
         manifests[split] = manifest
@@ -265,6 +297,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--splits", type=str, default="train,val,test", help="Comma-separated splits to preprocess (must include train)")
     parser.add_argument("--output-root", type=str, default=str(DEFAULT_OUTPUT_ROOT), help="Output directory for prepared artifacts")
     parser.add_argument("--sample-per-split", type=int, default=None, help="Optional limit of examples to process per split")
+    parser.add_argument("--lemma-corpus", type=str, default=None, help="Optional lemma corpus JSONL for library premise labels")
     parser.add_argument("--force", action="store_true", help="Overwrite the output root if it already exists")
     return parser
 
@@ -279,6 +312,7 @@ def main(argv: list[str] | None = None) -> int:
             splits=tuple(_normalize_splits(args.splits)),
             output_root=Path(args.output_root),
             sample_per_split=args.sample_per_split,
+            lemma_corpus_path=None if args.lemma_corpus is None else Path(args.lemma_corpus),
             force=args.force,
         )
         run_preprocessing(config)
@@ -287,3 +321,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/configs/pointer_graphsage_state.json
+++ b/configs/pointer_graphsage_state.json
@@ -9,7 +9,7 @@
   "max_args": 3,
   "arg_loss_weight": 0.5,
   "model": {
-    "hidden_dim": 128,
+    "hidden_dim": 512,
     "num_layers": 4,
     "dropout": 0.2
   },

--- a/configs/pointer_graphsage_state.json
+++ b/configs/pointer_graphsage_state.json
@@ -3,7 +3,7 @@
   "prepared_root": "artifacts/prepared/v1",
   "run_root": "runs/pointer_gnn",
   "seed": 42,
-  "device": "cuda",
+  "device": "auto",
   "edge_mode": "bidirectional",
   "use_node_type": true,
   "max_args": 3,

--- a/configs/premise_scoring.json
+++ b/configs/premise_scoring.json
@@ -1,0 +1,7 @@
+{
+  "k": 500,
+  "rerank_size": 50,
+  "scoring_mode": "dot",
+  "tactic_conditioning": "soft",
+  "premise_loss_weight": 0.3
+}

--- a/configs/premise_scoring.json
+++ b/configs/premise_scoring.json
@@ -1,5 +1,5 @@
 {
-  "k": 500,
+  "k": 200,
   "rerank_size": 50,
   "scoring_mode": "dot",
   "tactic_conditioning": "soft",

--- a/docs/Premise_Selection_Architecture.md
+++ b/docs/Premise_Selection_Architecture.md
@@ -1,0 +1,90 @@
+# Premise Selection Architecture & Pipeline
+
+This document explains the end-to-end flow for how the GNN predicts premises (both local hypotheses and external library lemmas) to solve Lean 4 proof states. It breaks down the entire pipeline and exactly what each file is responsible for.
+
+## High-Level Pipeline
+
+The premise selection pipeline is built in **four main stages**:
+
+1. **Corpus Extraction**: Extracting a mapping of all mathematical lemmas available in Mathlib from the LeanDojo Hugging Face dataset.
+2. **Baseline GNN (Frozen)**: A `GraphSAGEStateClassifier` that encodes Lean 4 abstract syntax trees (DAGs) into 512-dimensional vector embeddings. 
+3. **Lemma Indexing**: Passing all lemmas from the Corpus through the Baseline GNN to create static embeddings, which are stored in a highly-optimized FAISS vector database.
+4. **Premise Scorer Training**: Training a lightweight neural network (the Scorer) on top of the frozen GNN. It retrieves the top $K$ lemmas from FAISS, combines them with local hypotheses in the proof state, and ranks them to find the true premise.
+5. **Inference**: Passing a new proof state through the pipeline to predict the best tactic and its exact arguments.
+
+---
+
+## 1. Data Preparation
+
+### `scripts/extract_lemma_corpus_from_hf.py` & `scripts/build_lemma_corpus.py`
+These scripts download the raw LeanDojo training dataset from Hugging Face and extract every single theorem and lemma it contains. 
+- **Output:** `artifacts/lemmas/v1/corpus/lemmas.jsonl`
+- **Why it matters:** The FAISS index only understands IDs (e.g., Lemma #425). We need this corpus so that when FAISS returns ID #425, we know it corresponds to `Algebra.add_comm`.
+
+---
+
+## 2. Indexing the Math Library
+
+### `scripts/build_lemma_index.py` & `atp_lean_gnn/lemma_index.py`
+Once you have a trained baseline GNN (`best.pt`), we need to encode all the lemmas in the corpus so we can quickly search them later.
+- `build_lemma_index.py` loads the corpus and passes each lemma's graph representation through the frozen GNN.
+- `lemma_index.py` wraps the `faiss` library. It takes the 512-dimensional vector outputs from the GNN and builds an optimized similarity search index.
+- **Output:** `artifacts/lemmas/v1/index/lemma_index.faiss`
+- **Why it matters:** Instead of comparing a proof state against 60,000 lemmas one-by-one (which is computationally impossible during training), we can query the FAISS index to instantly get the Top-500 most mathematically similar lemmas.
+
+---
+
+## 3. Training the Premise Scorer
+
+This is the most complex part of the pipeline. We freeze the heavy GNN backbone and only train the tactic and premise selection heads.
+
+### `scripts/train_scorer.py`
+The entry point for training. It loads the frozen baseline model, the FAISS index, and the datasets, and initializes the `TacticWithArgsClassifier` and `PremiseScorer`.
+
+### `atp_lean_gnn/argument_selector.py`
+Contains the `TacticWithArgsClassifier`. This wraps the baseline GNN. 
+- It encodes the nodes in the graph (`model.backbone.encode_nodes`).
+- It extracts the single vector representing the entire proof state (`model.backbone.readout`).
+- It predicts the tactic (e.g., `rw`, `apply`).
+
+### `atp_lean_gnn/premise_pool.py`
+Contains `build_unified_pools()`.
+For every proof state in a training batch, this file is responsible for gathering the "candidates".
+1. It queries FAISS with the proof state embedding to get the top 500 **library lemmas**.
+2. It extracts the embeddings for the **local hypotheses** (nodes in the graph that belong to the current context).
+3. It merges them into a single `CandidatePool`.
+
+### `atp_lean_gnn/premise_scoring.py`
+Contains the `PremiseScorer` neural network and the loss function.
+- `PremiseScorer.score()` takes the proof state embedding, the tactic embedding, and the `CandidatePool`. It computes a score for every candidate.
+- `compute_premise_ranking_loss()` looks at the ground-truth targets (which premise was *actually* used by the human to solve this step). It finds where that premise is inside the `CandidatePool`, and penalizes the network if the true premise isn't ranked #1.
+
+### `atp_lean_gnn/premise_training.py`
+The actual training loop (`train_one_epoch_with_premises`).
+1. It handles PyTorch Geometric's complex batching (unflattening 1D variable-length lists into 2D padded matrices using `arg_count`).
+2. It runs the forward passes.
+3. It combines the loss from predicting the tactic with the loss from ranking the premises.
+
+---
+
+## 4. Inference (Prediction)
+
+When you want to solve a brand new theorem interactively, the pipeline runs the reverse process.
+
+### `scripts/run_inference.py`
+The CLI tool. You pass it a JSON proof state, and it loads the model, FAISS index, and the corpus. 
+
+### `atp_lean_gnn/inference.py`
+Contains `InferencePipeline`.
+1. It converts your JSON proof state into a PyTorch Geometric DAG.
+2. It passes the DAG through the GNN to get the proof state embedding.
+3. It asks the model: *"What tactic should I use?"* -> Model says: `rw`.
+4. It checks the arity (how many arguments does `rw` need? It needs 1).
+5. It queries the FAISS index with the proof state embedding to get the top 500 lemmas.
+6. It merges the FAISS lemmas with your local variables into a `CandidatePool`.
+7. It asks the `PremiseScorer` to score the pool.
+8. It takes the highest-scoring candidate. If it's a local variable, it returns the variable ID. If it's a FAISS lemma, it looks up the ID in the Corpus to return the human-readable string (e.g., `Algebra.add_comm`).
+9. **Result:** `rw [Algebra.add_comm]`
+
+---
+

--- a/docs/Premise_Selection_Architecture.md
+++ b/docs/Premise_Selection_Architecture.md
@@ -88,3 +88,42 @@ Contains `InferencePipeline`.
 
 ---
 
+## Quick Start / Execution Commands
+
+Here are the exact commands to run the pipeline end-to-end:
+
+**1. Extract Lemma Corpus:**
+```bash
+python scripts/extract_lemma_corpus_from_hf.py \
+    --dataset artifacts/leandojo_data/leandojo_benchmark_4/random/train.json \
+    --output artifacts/lemmas/v1/corpus/lemmas.jsonl
+```
+
+**2. Build FAISS Index (Requires a frozen baseline checkpoint):**
+```bash
+python scripts/build_lemma_index.py \
+    --corpus artifacts/lemmas/v1/corpus/lemmas.jsonl \
+    --config configs/pointer_graphsage_state.json \
+    --checkpoint run_20260602_155913/best.pt \
+    --output-dir artifacts/lemmas/v1/index
+```
+
+**3. Train the Premise Scorer:**
+```bash
+python scripts/train_scorer.py \
+    --config configs/pointer_graphsage_state.json \
+    --checkpoint runs/pointer_gnn/baseline_best.pt \
+    --index-path artifacts/lemmas/v1/index
+```
+
+**4. Run Inference (Evaluation):**
+```bash
+python scripts/run_inference.py \
+    --config runs/premise_gnn/run_latest/config.json \
+    --checkpoint runs/premise_gnn/run_latest/best.pt \
+    --index-path artifacts/lemmas/v1/index \
+    --corpus artifacts/lemmas/v1/corpus/lemmas.jsonl \
+    --test-file path/to/proof_state.json
+```
+
+---

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,7 @@
 # will run on the CPU.
 
 datasets>=2.20
+faiss-cpu>=1.8
+numpy>=1.26
 torch>=2.4
 torch-geometric>=2.5

--- a/scripts/build_lemma_corpus.py
+++ b/scripts/build_lemma_corpus.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+if __package__ in {None, ""}:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
+
+from atp_lean_gnn.lemma_corpus import LemmaRecord, write_lemma_corpus
+
+
+DEFAULT_OUTPUT_DIR = Path("artifacts") / "lemmas" / "v1" / "corpus"
+
+
+@dataclass(frozen=True)
+class CorpusBuildResult:
+    total_count: int
+    success_count: int
+    failure_count: int
+    deduped_count: int
+
+
+def _read_jsonl(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        for line_index, line in enumerate(handle, start=1):
+            raw = line.strip()
+            if not raw:
+                continue
+            try:
+                yield line_index, json.loads(raw)
+            except json.JSONDecodeError as exc:
+                yield line_index, {"_error": f"invalid_json: {exc}"}
+
+
+def _normalize_record(payload: dict[str, object]) -> tuple[str, str, str, str] | None:
+    name = str(payload.get("name", "")).strip()
+    statement = str(payload.get("statement") or payload.get("type") or "").strip()
+    namespace = str(payload.get("namespace", "")).strip()
+    module = str(payload.get("module", "")).strip()
+
+    if not name or not statement:
+        return None
+
+    if not namespace and "." in name:
+        namespace = name.rsplit(".", 1)[0]
+    return name, statement, namespace, module
+
+
+def build_corpus(
+    input_jsonl: Path,
+    *,
+    output_dir: Path,
+    sample_limit: int | None,
+    dedupe: bool,
+    force: bool,
+) -> CorpusBuildResult:
+    if not input_jsonl.exists():
+        raise FileNotFoundError(f"Input JSONL file not found: '{input_jsonl}'.")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    corpus_path = output_dir / "lemmas.jsonl"
+    failures_path = output_dir / "failures.jsonl"
+    manifest_path = output_dir / "manifest.json"
+
+    if corpus_path.exists() and not force:
+        raise FileExistsError(
+            f"Output '{corpus_path}' already exists. Use --force to overwrite."
+        )
+
+    records: list[LemmaRecord] = []
+    failures: list[dict[str, object]] = []
+    seen_names: set[str] = set()
+    total_count = 0
+    deduped_count = 0
+
+    for line_index, payload in _read_jsonl(input_jsonl):
+        if sample_limit is not None and total_count >= sample_limit:
+            break
+        total_count += 1
+
+        if "_error" in payload:
+            failures.append({"line_index": line_index, "reason": payload["_error"]})
+            continue
+
+        normalized = _normalize_record(payload)
+        if normalized is None:
+            failures.append({"line_index": line_index, "reason": "missing_name_or_statement"})
+            continue
+
+        name, statement, namespace, module = normalized
+        if dedupe and name in seen_names:
+            deduped_count += 1
+            continue
+
+        lemma_id = len(records)
+        records.append(
+            LemmaRecord(
+                lemma_id=lemma_id,
+                name=name,
+                statement=statement,
+                namespace=namespace,
+                module=module,
+            )
+        )
+        seen_names.add(name)
+
+    write_lemma_corpus(corpus_path, records)
+
+    if failures:
+        with failures_path.open("w", encoding="utf-8") as handle:
+            for failure in failures:
+                handle.write(json.dumps(failure, ensure_ascii=False, sort_keys=True))
+                handle.write("\n")
+
+    manifest = {
+        "input_jsonl": str(input_jsonl),
+        "output_dir": str(output_dir),
+        "total_count": total_count,
+        "success_count": len(records),
+        "failure_count": len(failures),
+        "deduped_count": deduped_count,
+        "sample_limit": sample_limit,
+        "dedupe": dedupe,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+
+    return CorpusBuildResult(
+        total_count=total_count,
+        success_count=len(records),
+        failure_count=len(failures),
+        deduped_count=deduped_count,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a normalized lemma corpus JSONL.")
+    parser.add_argument("--input-jsonl", type=str, required=True, help="Source JSONL with lemma records")
+    parser.add_argument("--output-dir", type=str, default=str(DEFAULT_OUTPUT_DIR), help="Output directory")
+    parser.add_argument("--sample-limit", type=int, default=None, help="Optional cap on processed rows")
+    parser.add_argument("--dedupe", action="store_true", help="Deduplicate by lemma name")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing corpus artifacts")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = build_corpus(
+            Path(args.input_jsonl),
+            output_dir=Path(args.output_dir),
+            sample_limit=args.sample_limit,
+            dedupe=args.dedupe,
+            force=args.force,
+        )
+    except (FileExistsError, FileNotFoundError, ValueError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print(
+        "Built lemma corpus: "
+        f"total={result.total_count}, "
+        f"success={result.success_count}, "
+        f"failed={result.failure_count}, "
+        f"deduped={result.deduped_count}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_lemma_index.py
+++ b/scripts/build_lemma_index.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import torch
+from torch_geometric.data import Batch
+
+
+if __package__ in {None, ""}:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
+
+from atp_lean_gnn.graph import lemma_statement_to_dag
+from atp_lean_gnn.lemma_corpus import load_lemma_corpus
+from atp_lean_gnn.pyg import dag_to_pyg
+from atp_lean_gnn.training import (
+    BaselineConfig,
+    build_model,
+    load_baseline_config,
+    load_prepared_metadata,
+    resolve_device,
+    transform_edge_index,
+)
+
+
+DEFAULT_OUTPUT_DIR = Path("artifacts") / "lemmas" / "v1" / "index"
+
+
+@dataclass(frozen=True)
+class IndexBuildResult:
+    total_count: int
+    success_count: int
+    failure_count: int
+
+
+def _normalize_rows(array: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(array, axis=1, keepdims=True)
+    norms = np.clip(norms, 1e-12, None)
+    return array / norms
+
+
+def _load_config_from_checkpoint(
+    checkpoint_path: Path,
+    *,
+    config_path: Path | None,
+) -> BaselineConfig:
+    if config_path is not None:
+        return load_baseline_config(config_path)
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    if "config" in checkpoint:
+        return BaselineConfig.from_dict(checkpoint["config"])
+
+    candidate = checkpoint_path.parent / "config.json"
+    if candidate.exists():
+        return load_baseline_config(candidate)
+
+    raise FileNotFoundError(
+        "Unable to infer model config. Provide --config or place config.json next to the checkpoint."
+    )
+
+
+def _state_node_id(dag) -> int:
+    for node in dag.nodes:
+        if node.label == "State":
+            return node.id
+    raise ValueError("Lemma DAG is missing the State node.")
+
+
+def _iter_batches(items: list, batch_size: int) -> Iterable[list]:
+    batch: list = []
+    for item in items:
+        batch.append(item)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def build_index(
+    *,
+    corpus_path: Path,
+    output_dir: Path,
+    prepared_root: Path,
+    checkpoint_path: Path,
+    config_path: Path | None,
+    device_name: str,
+    edge_mode: str,
+    batch_size: int,
+    limit: int | None,
+    normalize: bool,
+) -> IndexBuildResult:
+    import faiss
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    vectors_path = output_dir / "lemma_vectors.npy"
+    ids_path = output_dir / "lemma_ids.json"
+    index_path = output_dir / "faiss.index"
+    failures_path = output_dir / "failures.jsonl"
+    manifest_path = output_dir / "manifest.json"
+
+    metadata = load_prepared_metadata(prepared_root)
+    config = _load_config_from_checkpoint(checkpoint_path, config_path=config_path)
+    device = resolve_device(device_name)
+
+    model = build_model(metadata, config).to(device)
+    checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=False)
+    model.load_state_dict(checkpoint["model_state_dict"])
+    model.eval()
+
+    records = load_lemma_corpus(corpus_path)
+    if limit is not None:
+        records = records[:limit]
+
+    lemma_ids: list[int] = []
+    lemma_vectors: list[np.ndarray] = []
+    failures: list[dict[str, object]] = []
+
+    for batch in _iter_batches(records, batch_size):
+        data_list = []
+        batch_ids: list[int] = []
+        for record in batch:
+            try:
+                dag = lemma_statement_to_dag(record.statement)
+                data = dag_to_pyg(dag, metadata.node_vocab)
+                data.state_node_index = torch.tensor([_state_node_id(dag)], dtype=torch.long)
+                data.edge_index = transform_edge_index(data.edge_index, edge_mode=edge_mode)
+                data_list.append(data)
+                batch_ids.append(record.lemma_id)
+            except Exception as exc:
+                failures.append(
+                    {
+                        "lemma_id": record.lemma_id,
+                        "name": record.name,
+                        "reason": str(exc),
+                    }
+                )
+
+        if not data_list:
+            continue
+
+        batch_data = Batch.from_data_list(data_list).to(device)
+        with torch.no_grad():
+            node_embeddings = model.encode_nodes(batch_data)
+            state_emb = model.readout(node_embeddings, batch_data)
+        vectors = state_emb.detach().cpu().numpy().astype(np.float32)
+
+        lemma_ids.extend(batch_ids)
+        lemma_vectors.append(vectors)
+
+    if lemma_vectors:
+        lemma_vectors_np = np.concatenate(lemma_vectors, axis=0)
+    else:
+        lemma_vectors_np = np.zeros((0, config.model.hidden_dim), dtype=np.float32)
+
+    if normalize and lemma_vectors_np.size > 0:
+        lemma_vectors_np = _normalize_rows(lemma_vectors_np)
+
+    np.save(vectors_path, lemma_vectors_np)
+    ids_path.write_text(json.dumps(lemma_ids, indent=2), encoding="utf-8")
+
+    index = faiss.IndexFlatIP(lemma_vectors_np.shape[1])
+    if lemma_vectors_np.size > 0:
+        index.add(lemma_vectors_np)
+    faiss.write_index(index, str(index_path))
+
+    if failures:
+        with failures_path.open("w", encoding="utf-8") as handle:
+            for failure in failures:
+                handle.write(json.dumps(failure, ensure_ascii=False, sort_keys=True))
+                handle.write("\n")
+
+    manifest = {
+        "corpus_path": str(corpus_path),
+        "prepared_root": str(prepared_root),
+        "checkpoint_path": str(checkpoint_path),
+        "config_path": None if config_path is None else str(config_path),
+        "edge_mode": edge_mode,
+        "batch_size": batch_size,
+        "normalize": normalize,
+        "total_count": len(records),
+        "success_count": len(lemma_ids),
+        "failure_count": len(failures),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+
+    return IndexBuildResult(
+        total_count=len(records),
+        success_count=len(lemma_ids),
+        failure_count=len(failures),
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build FAISS index for lemma embeddings.")
+    parser.add_argument("--corpus-path", type=str, required=True, help="Path to lemmas.jsonl")
+    parser.add_argument("--output-dir", type=str, default=str(DEFAULT_OUTPUT_DIR), help="Output directory")
+    parser.add_argument("--prepared-root", type=str, required=True, help="Prepared dataset root")
+    parser.add_argument("--checkpoint", type=str, required=True, help="Model checkpoint path")
+    parser.add_argument("--config", type=str, default=None, help="Optional baseline config path")
+    parser.add_argument("--device", type=str, default="auto", help="auto, cpu, or cuda")
+    parser.add_argument("--edge-mode", type=str, default="bidirectional", help="forward or bidirectional")
+    parser.add_argument("--batch-size", type=int, default=128, help="Batch size for embedding")
+    parser.add_argument("--limit", type=int, default=None, help="Optional cap on lemmas")
+    parser.add_argument("--normalize", action="store_true", help="L2-normalize embeddings")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = build_index(
+            corpus_path=Path(args.corpus_path),
+            output_dir=Path(args.output_dir),
+            prepared_root=Path(args.prepared_root),
+            checkpoint_path=Path(args.checkpoint),
+            config_path=None if args.config is None else Path(args.config),
+            device_name=str(args.device),
+            edge_mode=str(args.edge_mode),
+            batch_size=int(args.batch_size),
+            limit=args.limit,
+            normalize=bool(args.normalize),
+        )
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print(
+        "Built lemma index: "
+        f"total={result.total_count}, "
+        f"success={result.success_count}, "
+        f"failed={result.failure_count}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/extract_lemma_corpus_from_hf.py
+++ b/scripts/extract_lemma_corpus_from_hf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Extract a lemma corpus from the LeanDojo benchmark on HuggingFace.
 
 This script streams the LeanDojo benchmark dataset, collects unique theorem

--- a/scripts/extract_lemma_corpus_from_hf.py
+++ b/scripts/extract_lemma_corpus_from_hf.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Extract a lemma corpus from the LeanDojo benchmark on HuggingFace.
+
+This script streams the LeanDojo benchmark dataset, collects unique theorem
+names and their proof-state goals, and writes a JSONL corpus compatible with
+``atp_lean_gnn.lemma_corpus.LemmaRecord``.
+
+Usage::
+
+    python scripts/extract_lemma_corpus_from_hf.py \
+        --output-dir artifacts/lemmas/v1/corpus \
+        --sample-limit 500 --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
+
+from atp_lean_gnn.dataset import DATASET_NAME, stream_split
+from atp_lean_gnn.lemma_corpus import LemmaRecord, write_lemma_corpus
+from atp_lean_gnn.state import parse_state
+
+
+DEFAULT_OUTPUT_DIR = Path("artifacts") / "lemmas" / "v1" / "corpus"
+SAMPLE_SIZE = 50
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    total_rows_scanned: int
+    unique_theorems: int
+    parse_failures: int
+    sample_count: int
+
+
+def _extract_goal_from_state(state_str: str) -> str | None:
+    """Parse a proof state string and return the goal expression.
+
+    Returns ``None`` if the state cannot be parsed.
+    """
+    try:
+        parsed = parse_state(state_str)
+        return parsed.goal if parsed.goal else None
+    except Exception:
+        return None
+
+
+def _infer_namespace(full_name: str) -> str:
+    """Infer namespace from a dotted fully-qualified name."""
+    if "." in full_name:
+        return full_name.rsplit(".", 1)[0]
+    return ""
+
+
+def extract_corpus(
+    *,
+    output_dir: Path,
+    dataset_name: str = DATASET_NAME,
+    split: str = "train",
+    sample_limit: int | None = None,
+    force: bool = False,
+) -> ExtractionResult:
+    """Stream the dataset and write a deduplicated lemma corpus.
+
+    For each unique ``full_name`` (theorem), we take the goal expression from
+    its first occurrence as the lemma *statement*.  This gives us a reasonable
+    approximation of each Mathlib theorem's type signature.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    corpus_path = output_dir / "lemmas.jsonl"
+    manifest_path = output_dir / "manifest.json"
+    sample_path = output_dir / "lemmas_sample.jsonl"
+    failures_path = output_dir / "failures.jsonl"
+
+    if corpus_path.exists() and not force:
+        raise FileExistsError(
+            f"Output '{corpus_path}' already exists. Use --force to overwrite."
+        )
+
+    seen_names: dict[str, str] = {}  # full_name → goal statement
+    parse_failures: list[dict[str, object]] = []
+    total_rows = 0
+
+    print(f"  Streaming {dataset_name} split='{split}'...")
+
+    for row in stream_split(split, limit=sample_limit, dataset_name=dataset_name):
+        total_rows += 1
+        full_name = row.theorem.strip()
+
+        if not full_name:
+            parse_failures.append(
+                {"row_index": row.row_index, "reason": "empty_full_name"}
+            )
+            continue
+
+        # Only take the first occurrence of each theorem
+        if full_name in seen_names:
+            continue
+
+        goal = _extract_goal_from_state(row.state)
+        if goal is None:
+            parse_failures.append(
+                {
+                    "row_index": row.row_index,
+                    "full_name": full_name,
+                    "reason": "state_parse_failure",
+                }
+            )
+            continue
+
+        seen_names[full_name] = goal
+
+        if total_rows % 10000 == 0:
+            print(
+                f"    scanned {total_rows} rows, "
+                f"{len(seen_names)} unique theorems so far..."
+            )
+
+    # Build LemmaRecord list
+    records: list[LemmaRecord] = []
+    for lemma_id, (name, statement) in enumerate(seen_names.items()):
+        records.append(
+            LemmaRecord(
+                lemma_id=lemma_id,
+                name=name,
+                statement=statement,
+                namespace=_infer_namespace(name),
+                module="",
+            )
+        )
+
+    # Write full corpus
+    write_lemma_corpus(corpus_path, records)
+
+    # Write sample (first N records)
+    sample_records = records[:SAMPLE_SIZE]
+    write_lemma_corpus(sample_path, sample_records)
+
+    # Write failures
+    if parse_failures:
+        with failures_path.open("w", encoding="utf-8") as handle:
+            for failure in parse_failures:
+                handle.write(
+                    json.dumps(failure, ensure_ascii=False, sort_keys=True)
+                )
+                handle.write("\n")
+
+    # Write manifest
+    manifest = {
+        "source_dataset": dataset_name,
+        "source_split": split,
+        "total_rows_scanned": total_rows,
+        "unique_theorems": len(records),
+        "parse_failures": len(parse_failures),
+        "sample_limit": sample_limit,
+        "sample_count": len(sample_records),
+        "corpus_path": str(corpus_path),
+        "sample_path": str(sample_path),
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+    result = ExtractionResult(
+        total_rows_scanned=total_rows,
+        unique_theorems=len(records),
+        parse_failures=len(parse_failures),
+        sample_count=len(sample_records),
+    )
+    return result
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Extract a lemma corpus from the LeanDojo HuggingFace dataset."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Output directory for corpus artifacts",
+    )
+    parser.add_argument(
+        "--dataset-name",
+        type=str,
+        default=DATASET_NAME,
+        help="HuggingFace dataset identifier",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="train",
+        help="Dataset split to extract from (default: train)",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=None,
+        help="Optional cap on total rows streamed from the dataset",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing corpus artifacts",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = extract_corpus(
+            output_dir=Path(args.output_dir),
+            dataset_name=args.dataset_name,
+            split=args.split,
+            sample_limit=args.sample_limit,
+            force=args.force,
+        )
+    except (FileExistsError, FileNotFoundError, RuntimeError, ValueError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print(
+        f"\nExtracted lemma corpus:\n"
+        f"  rows scanned   = {result.total_rows_scanned}\n"
+        f"  unique theorems = {result.unique_theorems}\n"
+        f"  parse failures  = {result.parse_failures}\n"
+        f"  sample entries  = {result.sample_count}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+
 """Run tactic inference on a single proof state interactively."""
 
 import argparse
@@ -16,9 +16,9 @@ if __package__ in {None, ""}:
 from atp_lean_gnn.cli import DEMO_STATE
 from atp_lean_gnn.inference import InferencePipeline
 from atp_lean_gnn.lemma_index import LemmaIndex
-from atp_lean_gnn.training import load_prepared_metadata, load_baseline_config
-from atp_lean_gnn.model import build_model
+from atp_lean_gnn.training import load_prepared_metadata, load_baseline_config, build_model
 from atp_lean_gnn.premise_scoring import PremiseScorer
+from atp_lean_gnn.lemma_corpus import load_lemma_corpus
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -27,6 +27,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--checkpoint", type=str, required=True, help="Path to best.pt checkpoint")
     parser.add_argument("--scorer-mode", type=str, default="dot", choices=["dot", "mlp"], help="Scorer mode")
     parser.add_argument("--index-path", type=str, help="Path to FAISS index. If missing, retrieval will return nothing.")
+    parser.add_argument("--corpus-path", type=str, help="Path to lemmas.jsonl for decoding retrieved lemma IDs to names.")
     parser.add_argument("--k", type=int, default=500, help="Number of lemmas to retrieve")
     parser.add_argument("--state", type=str, default=DEMO_STATE, help="Raw Lean proof state string")
     args = parser.parse_args(argv)
@@ -44,21 +45,31 @@ def main(argv: list[str] | None = None) -> int:
     metadata = load_prepared_metadata(config.prepared_root)
 
     # Build and load model
-    model = build_model(metadata, config)
+    from atp_lean_gnn.argument_selector import TacticWithArgsClassifier
+    
+    model = TacticWithArgsClassifier(
+        num_node_labels=len(metadata.node_vocab),
+        num_tactics=len(metadata.tactic_vocab),
+        hidden_dim=config.model.hidden_dim,
+        num_layers=config.model.num_layers,
+        dropout=config.model.dropout,
+        use_node_type=config.use_node_type,
+        max_args=getattr(config, "max_args", 3),
+    )
+    
     ckpt = torch.load(args.checkpoint, map_location=device, weights_only=False)
+    state_dict = ckpt["model_state_dict"] if "model_state_dict" in ckpt else ckpt
     
-    # Check if the checkpoint contains a full model or just the state dict
-    if "model_state_dict" in ckpt:
-        # Checkpoint from our custom training loop
-        # It might be a TacticWithArgsClassifier or GraphSAGEStateClassifier
-        # We handle this by loading into whatever build_model returned.
-        # But wait, build_model returns TacticWithArgsClassifier if config.model_type == "pointer",
-        # else GraphSAGEStateClassifier.
-        model.load_state_dict(ckpt["model_state_dict"])
-    else:
-        # Bare state dict
-        model.load_state_dict(ckpt)
-    
+    # Adjust state dict keys if they come from a pure baseline (GraphSAGEStateClassifier)
+    # The pure baseline keys don't have the "backbone." prefix.
+    adjusted_state_dict = {}
+    for k, v in state_dict.items():
+        if not k.startswith("backbone.") and not k.startswith("tactic_embedding.") and not k.startswith("argument_selector."):
+            adjusted_state_dict[f"backbone.{k}"] = v
+        else:
+            adjusted_state_dict[k] = v
+            
+    model.load_state_dict(adjusted_state_dict, strict=False)
     model = model.to(device)
 
     # Build scorer (using randomly initialized weights for demo if not loaded)
@@ -70,14 +81,30 @@ def main(argv: list[str] | None = None) -> int:
         index_path = Path(args.index_path)
         if index_path.exists():
             lemma_index = LemmaIndex.load(index_path)
-            print(f"Loaded index with {len(lemma_index)} lemmas.")
+            print(f"Loaded index with {len(lemma_index.lemma_ids)} lemmas.")
         else:
             print(f"WARNING: index path {index_path} not found.")
             
     if lemma_index is None:
         # Create an empty index as fallback
-        from atp_lean_gnn.lemma_index import LemmaIndexConfig
-        lemma_index = LemmaIndex(LemmaIndexConfig(hidden_dim=config.model.hidden_dim))
+        import faiss
+        import numpy as np
+        d = config.model.hidden_dim
+        lemma_index = LemmaIndex(
+            index=faiss.IndexFlatL2(d),
+            lemma_ids=[],
+            lemma_vectors=np.empty((0, d), dtype=np.float32)
+        )
+
+    lemma_corpus = None
+    if args.corpus_path:
+        corpus_path = Path(args.corpus_path)
+        if corpus_path.exists():
+            records = load_lemma_corpus(corpus_path)
+            lemma_corpus = {record.lemma_id: record for record in records}
+            print(f"Loaded corpus with {len(lemma_corpus)} lemmas.")
+        else:
+            print(f"WARNING: corpus path {corpus_path} not found.")
 
     # Initialize Pipeline
     pipeline = InferencePipeline(
@@ -88,6 +115,7 @@ def main(argv: list[str] | None = None) -> int:
         tactic_vocab=metadata.tactic_vocab,
         device=device,
         k=args.k,
+        lemma_corpus=lemma_corpus,
     )
 
     print("\n--- Input State ---")

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Run tactic inference on a single proof state interactively."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+
+if __package__ in {None, ""}:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
+from atp_lean_gnn.cli import DEMO_STATE
+from atp_lean_gnn.inference import InferencePipeline
+from atp_lean_gnn.lemma_index import LemmaIndex
+from atp_lean_gnn.training import load_prepared_metadata, load_baseline_config
+from atp_lean_gnn.model import build_model
+from atp_lean_gnn.premise_scoring import PremiseScorer
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Interactive Tactic Inference")
+    parser.add_argument("--config", type=str, required=True, help="Path to config.json (e.g. from runs/baseline_gnn/run_*/config.json)")
+    parser.add_argument("--checkpoint", type=str, required=True, help="Path to best.pt checkpoint")
+    parser.add_argument("--scorer-mode", type=str, default="dot", choices=["dot", "mlp"], help="Scorer mode")
+    parser.add_argument("--index-path", type=str, help="Path to FAISS index. If missing, retrieval will return nothing.")
+    parser.add_argument("--k", type=int, default=500, help="Number of lemmas to retrieve")
+    parser.add_argument("--state", type=str, default=DEMO_STATE, help="Raw Lean proof state string")
+    args = parser.parse_args(argv)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Loading on {device}...")
+
+    # Load baseline config and metadata
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"ERROR: config file not found: {config_path}")
+        return 1
+
+    config = load_baseline_config(config_path)
+    metadata = load_prepared_metadata(config.prepared_root)
+
+    # Build and load model
+    model = build_model(metadata, config)
+    ckpt = torch.load(args.checkpoint, map_location=device, weights_only=False)
+    
+    # Check if the checkpoint contains a full model or just the state dict
+    if "model_state_dict" in ckpt:
+        # Checkpoint from our custom training loop
+        # It might be a TacticWithArgsClassifier or GraphSAGEStateClassifier
+        # We handle this by loading into whatever build_model returned.
+        # But wait, build_model returns TacticWithArgsClassifier if config.model_type == "pointer",
+        # else GraphSAGEStateClassifier.
+        model.load_state_dict(ckpt["model_state_dict"])
+    else:
+        # Bare state dict
+        model.load_state_dict(ckpt)
+    
+    model = model.to(device)
+
+    # Build scorer (using randomly initialized weights for demo if not loaded)
+    scorer = PremiseScorer(hidden_dim=config.model.hidden_dim, mode=args.scorer_mode).to(device)
+    
+    # Load index if provided
+    lemma_index = None
+    if args.index_path:
+        index_path = Path(args.index_path)
+        if index_path.exists():
+            lemma_index = LemmaIndex.load(index_path)
+            print(f"Loaded index with {len(lemma_index)} lemmas.")
+        else:
+            print(f"WARNING: index path {index_path} not found.")
+            
+    if lemma_index is None:
+        # Create an empty index as fallback
+        from atp_lean_gnn.lemma_index import LemmaIndexConfig
+        lemma_index = LemmaIndex(LemmaIndexConfig(hidden_dim=config.model.hidden_dim))
+
+    # Initialize Pipeline
+    pipeline = InferencePipeline(
+        model=model,
+        scorer=scorer,
+        lemma_index=lemma_index,
+        node_vocab=metadata.node_vocab,
+        tactic_vocab=metadata.tactic_vocab,
+        device=device,
+        k=args.k,
+    )
+
+    print("\n--- Input State ---")
+    print(args.state)
+    print("-------------------\n")
+
+    prediction = pipeline.predict_tactic(args.state)
+    
+    print(f"Predicted Tactic:  \033[1;32m{prediction}\033[0m")
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/train_scorer.py
+++ b/scripts/train_scorer.py
@@ -50,7 +50,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--checkpoint", type=str, required=True, help="Path to baseline checkpoint (best.pt)")
     parser.add_argument("--index-path", type=str, required=True, help="Path to FAISS index built from the baseline")
     parser.add_argument("--run-root", type=str, default="runs/premise_gnn", help="Directory to save run logs and checkpoints")
-    parser.add_argument("--freeze-encoder", action="store_true", help="Freeze the GNN backbone and only train the scorer")
     args = parser.parse_args(argv)
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -99,20 +98,32 @@ def main(argv: list[str] | None = None) -> int:
             adjusted_state_dict[k] = v
             
     model.load_state_dict(adjusted_state_dict, strict=False)
-    
-    if args.freeze_encoder:
-        console_print("Freezing GNN encoder...")
-        for param in model.parameters():
-            param.requires_grad = False
-            
+
+    # Freeze the GNN backbone (keeps embeddings compatible with FAISS index)
+    for param in model.backbone.parameters():
+        param.requires_grad = False
+
     model = model.to(device)
 
     # Build Premise Scorer
     scorer = PremiseScorer(hidden_dim=config.model.hidden_dim, mode=p_config.scoring_mode)
     scorer = scorer.to(device)
 
+    # Only train: tactic_embedding, argument_selector, and scorer
+    trainable_params = (
+        list(model.tactic_embedding.parameters())
+        + list(model.argument_selector.parameters())
+        + list(scorer.parameters())
+    )
+    frozen_count = sum(p.numel() for p in model.backbone.parameters())
+    trainable_count = sum(p.numel() for p in trainable_params)
+    console_print(
+        f"Parameters — frozen backbone: {frozen_count:,}, "
+        f"trainable (pointer + scorer + tactic_emb): {trainable_count:,}"
+    )
+
     optimizer = AdamW(
-        [p for p in list(model.parameters()) + list(scorer.parameters()) if p.requires_grad],
+        trainable_params,
         lr=config.training.learning_rate,
         weight_decay=config.training.weight_decay,
     )

--- a/scripts/train_scorer.py
+++ b/scripts/train_scorer.py
@@ -99,6 +99,9 @@ def main(argv: list[str] | None = None) -> int:
             
     model.load_state_dict(adjusted_state_dict, strict=False)
 
+    with torch.no_grad():
+        model.tactic_embedding.weight.copy_(model.backbone.classifier.weight)
+
     # Freeze the GNN backbone (keeps embeddings compatible with FAISS index)
     for param in model.backbone.parameters():
         param.requires_grad = False

--- a/scripts/train_scorer.py
+++ b/scripts/train_scorer.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Train the premise scoring head on top of a frozen or fine-tuned baseline model.
+
+Usage::
+    python scripts/train_scorer.py \\
+        --config configs/pointer_graphsage_state.json \\
+        --premise-config configs/premise_scoring.json \\
+        --checkpoint runs/pointer_gnn/run_XXX/best.pt \\
+        --index-path artifacts/lemmas/v1/index/lemma_index.faiss
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import torch
+from torch.optim import AdamW
+
+if __package__ in {None, ""}:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
+from atp_lean_gnn.lemma_index import LemmaIndex
+from atp_lean_gnn.model import build_model
+from atp_lean_gnn.premise_scoring import PremiseScorer, PremiseScorerConfig
+from atp_lean_gnn.premise_training import evaluate_model_with_premises, train_one_epoch_with_premises
+from atp_lean_gnn.reporting import console_print
+from atp_lean_gnn.training import build_dataloaders, load_baseline_config, load_prepared_metadata
+
+
+def _create_run_dir(run_root: Path) -> Path:
+    run_root.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    candidate = run_root / f"run_{timestamp}"
+    suffix = 1
+    while candidate.exists():
+        candidate = run_root / f"run_{timestamp}_{suffix:02d}"
+        suffix += 1
+    candidate.mkdir(parents=True)
+    return candidate
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Train Premise Scorer")
+    parser.add_argument("--config", type=str, required=True, help="Path to baseline config")
+    parser.add_argument("--premise-config", type=str, default="configs/premise_scoring.json", help="Path to premise scoring config")
+    parser.add_argument("--checkpoint", type=str, required=True, help="Path to baseline checkpoint (best.pt)")
+    parser.add_argument("--index-path", type=str, required=True, help="Path to FAISS index built from the baseline")
+    parser.add_argument("--run-root", type=str, default="runs/premise_gnn", help="Directory to save run logs and checkpoints")
+    parser.add_argument("--freeze-encoder", action="store_true", help="Freeze the GNN backbone and only train the scorer")
+    args = parser.parse_args(argv)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    use_amp = device.type == "cuda"
+    
+    # Load configs
+    config = load_baseline_config(Path(args.config))
+    metadata = load_prepared_metadata(config.prepared_root)
+    
+    with open(args.premise_config, "r") as f:
+        p_cfg_dict = json.load(f)
+        p_config = PremiseScorerConfig(**p_cfg_dict)
+
+    run_dir = _create_run_dir(Path(args.run_root))
+    console_print(f"Saving run to {run_dir}")
+
+    # Load Lemma Index
+    console_print(f"Loading lemma index from {args.index_path}...")
+    lemma_index = LemmaIndex.load(Path(args.index_path))
+
+    # Build Dataloaders
+    datasets, loaders = build_dataloaders(metadata, config)
+
+    # Load baseline model
+    model = build_model(metadata, config)
+    ckpt = torch.load(args.checkpoint, map_location=device, weights_only=False)
+    if "model_state_dict" in ckpt:
+        model.load_state_dict(ckpt["model_state_dict"])
+    else:
+        model.load_state_dict(ckpt)
+    
+    if args.freeze_encoder:
+        console_print("Freezing GNN encoder...")
+        for param in model.parameters():
+            param.requires_grad = False
+            
+    model = model.to(device)
+
+    # Build Premise Scorer
+    scorer = PremiseScorer(hidden_dim=config.model.hidden_dim, mode=p_config.scoring_mode)
+    scorer = scorer.to(device)
+
+    optimizer = AdamW(
+        [p for p in list(model.parameters()) + list(scorer.parameters()) if p.requires_grad],
+        lr=config.training.learning_rate,
+        weight_decay=config.training.weight_decay,
+    )
+    grad_scaler = torch.amp.GradScaler(device.type, enabled=use_amp)
+
+    best_val_mrr = -1.0
+
+    for epoch in range(1, config.training.epochs + 1):
+        train_metrics = train_one_epoch_with_premises(
+            model=model,
+            scorer=scorer,
+            loader=loaders["train"],
+            lemma_index=lemma_index,
+            optimizer=optimizer,
+            grad_scaler=grad_scaler,
+            device=device,
+            grad_clip=config.training.grad_clip,
+            unknown_tactic_id=metadata.unknown_tactic_id,
+            arg_loss_weight=config.arg_loss_weight if hasattr(config, "arg_loss_weight") else 0.5,
+            premise_loss_weight=p_config.premise_loss_weight,
+            k=p_config.k,
+            epoch=epoch,
+            total_epochs=config.training.epochs,
+            log_every_batches=config.training.log_every_batches,
+            use_amp=use_amp,
+            pin_memory=config.training.pin_memory,
+        )
+
+        val_metrics = evaluate_model_with_premises(
+            model=model,
+            scorer=scorer,
+            loader=loaders["val"],
+            lemma_index=lemma_index,
+            device=device,
+            unknown_tactic_id=metadata.unknown_tactic_id,
+            arg_loss_weight=config.arg_loss_weight if hasattr(config, "arg_loss_weight") else 0.5,
+            premise_loss_weight=p_config.premise_loss_weight,
+            k=p_config.k,
+            split_name="val",
+            log_every_batches=config.training.log_every_batches,
+            use_amp=use_amp,
+            pin_memory=config.training.pin_memory,
+        )
+
+        console_print(
+            f"Epoch {epoch} | Val MRR: {val_metrics['premise_mrr']:.4f} | "
+            f"Hit@1: {val_metrics['premise_top1_accuracy']:.4f} | "
+            f"Hit@5: {val_metrics['premise_top5_accuracy']:.4f} | "
+            f"Recall: {val_metrics['premise_recall']:.4f}"
+        )
+
+        if val_metrics["premise_mrr"] > best_val_mrr:
+            best_val_mrr = val_metrics["premise_mrr"]
+            torch.save({
+                "epoch": epoch,
+                "model_state_dict": model.state_dict(),
+                "scorer_state_dict": scorer.state_dict(),
+                "val_metrics": val_metrics,
+            }, run_dir / "best.pt")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/train_scorer.py
+++ b/scripts/train_scorer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+
 """Train the premise scoring head on top of a frozen or fine-tuned baseline model.
 
 Usage::
@@ -25,11 +25,10 @@ if __package__ in {None, ""}:
         sys.path.insert(0, repo_root_str)
 
 from atp_lean_gnn.lemma_index import LemmaIndex
-from atp_lean_gnn.model import build_model
 from atp_lean_gnn.premise_scoring import PremiseScorer, PremiseScorerConfig
 from atp_lean_gnn.premise_training import evaluate_model_with_premises, train_one_epoch_with_premises
 from atp_lean_gnn.reporting import console_print
-from atp_lean_gnn.training import build_dataloaders, load_baseline_config, load_prepared_metadata
+from atp_lean_gnn.training import build_dataloaders, load_baseline_config, load_prepared_metadata, build_model
 
 
 def _create_run_dir(run_root: Path) -> Path:
@@ -75,13 +74,31 @@ def main(argv: list[str] | None = None) -> int:
     # Build Dataloaders
     datasets, loaders = build_dataloaders(metadata, config)
 
-    # Load baseline model
-    model = build_model(metadata, config)
+    # Load baseline model and wrap it in TacticWithArgsClassifier
+    from atp_lean_gnn.argument_selector import TacticWithArgsClassifier
+    
+    model = TacticWithArgsClassifier(
+        num_node_labels=len(metadata.node_vocab),
+        num_tactics=len(metadata.tactic_vocab),
+        hidden_dim=config.model.hidden_dim,
+        num_layers=config.model.num_layers,
+        dropout=config.model.dropout,
+        use_node_type=config.use_node_type,
+        max_args=getattr(config, "max_args", 3),
+    )
+    
     ckpt = torch.load(args.checkpoint, map_location=device, weights_only=False)
-    if "model_state_dict" in ckpt:
-        model.load_state_dict(ckpt["model_state_dict"])
-    else:
-        model.load_state_dict(ckpt)
+    state_dict = ckpt["model_state_dict"] if "model_state_dict" in ckpt else ckpt
+    
+    # Adjust state dict keys if they come from a pure baseline (GraphSAGEStateClassifier)
+    adjusted_state_dict = {}
+    for k, v in state_dict.items():
+        if not k.startswith("backbone.") and not k.startswith("tactic_embedding.") and not k.startswith("argument_selector."):
+            adjusted_state_dict[f"backbone.{k}"] = v
+        else:
+            adjusted_state_dict[k] = v
+            
+    model.load_state_dict(adjusted_state_dict, strict=False)
     
     if args.freeze_encoder:
         console_print("Freezing GNN encoder...")

--- a/tests/test_lemma_corpus.py
+++ b/tests/test_lemma_corpus.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from atp_lean_gnn.lemma_corpus import load_lemma_corpus, load_lemma_name_index, write_lemma_corpus, LemmaRecord
+
+
+class LemmaCorpusTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp_dir = Path("tests") / "_tmp_lemma_corpus"
+        self.tmp_dir.mkdir(parents=True, exist_ok=True)
+        self.corpus_path = self.tmp_dir / "lemmas.jsonl"
+
+    def tearDown(self) -> None:
+        if self.tmp_dir.exists():
+            for path in self.tmp_dir.iterdir():
+                path.unlink()
+            self.tmp_dir.rmdir()
+
+    def test_roundtrip_and_index(self) -> None:
+        records = [
+            LemmaRecord(lemma_id=0, name="Foo.bar", statement="x = x", namespace="Foo", module=""),
+            LemmaRecord(lemma_id=1, name="Baz.qux", statement="y = y", namespace="Baz", module=""),
+        ]
+        write_lemma_corpus(self.corpus_path, records)
+
+        loaded = load_lemma_corpus(self.corpus_path)
+        self.assertEqual(len(loaded), 2)
+        self.assertEqual(loaded[0].name, "Foo.bar")
+        self.assertEqual(loaded[1].name, "Baz.qux")
+
+        index = load_lemma_name_index(self.corpus_path)
+        self.assertEqual(index["Foo.bar"], 0)
+        self.assertEqual(index["Baz.qux"], 1)

--- a/tests/test_lemma_index.py
+++ b/tests/test_lemma_index.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import unittest
+import numpy as np
+import faiss
+
+from atp_lean_gnn.lemma_index import LemmaIndex
+
+
+class TestLemmaIndex(unittest.TestCase):
+    def test_search_empty_index(self) -> None:
+        dim = 8
+        index = faiss.IndexFlatL2(dim)
+        lemma_ids = []
+        lemma_vectors = np.empty((0, dim), dtype=np.float32)
+
+        lemma_index = LemmaIndex(index, lemma_ids, lemma_vectors)
+        
+        query = np.random.randn(2, dim).astype(np.float32)
+        # Search for 5 neighbors, which is more than the index size (0)
+        retrieved_ids, retrieved_vecs, scores = lemma_index.search(query, k=5)
+        
+        self.assertEqual(len(retrieved_ids), 2)
+        self.assertEqual(len(retrieved_ids[0]), 5)
+        self.assertEqual(retrieved_ids, [[-1] * 5, [-1] * 5])
+        self.assertEqual(retrieved_vecs.shape, (2, 5, dim))
+        self.assertTrue(np.all(retrieved_vecs == 0.0))
+
+    def test_search_partial_index(self) -> None:
+        dim = 8
+        index = faiss.IndexFlatL2(dim)
+        # Add 2 items
+        vectors = np.random.randn(2, dim).astype(np.float32)
+        index.add(vectors)
+        lemma_ids = [100, 101]
+        
+        lemma_index = LemmaIndex(index, lemma_ids, vectors)
+        
+        query = np.random.randn(1, dim).astype(np.float32)
+        # Search for 5 neighbors, which is more than the index size (2)
+        retrieved_ids, retrieved_vecs, scores = lemma_index.search(query, k=5)
+        
+        self.assertEqual(len(retrieved_ids), 1)
+        self.assertEqual(len(retrieved_ids[0]), 5)
+        
+        # The first 2 elements should be valid IDs (100 or 101)
+        # The remaining 3 elements should be -1
+        valid_ids = retrieved_ids[0][:2]
+        self.assertTrue(all(x in [100, 101] for x in valid_ids))
+        self.assertEqual(retrieved_ids[0][2:], [-1, -1, -1])
+        
+        self.assertEqual(retrieved_vecs.shape, (1, 5, dim))
+        # Check that the invalid indices' vectors are zeroed
+        self.assertTrue(np.all(retrieved_vecs[0, 2:] == 0.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_premise_pool.py
+++ b/tests/test_premise_pool.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import torch
+
+from atp_lean_gnn.premise_pool import build_unified_pools
+
+
+class _FakeLemmaIndex:
+    def search(self, goal_vecs, *, k):
+        batch_size = int(goal_vecs.size(0))
+        dim = int(goal_vecs.size(1))
+        lemma_ids = []
+        lemma_vecs = []
+        for b in range(batch_size):
+            lemma_ids.append([100 + 2 * b, 100 + 2 * b + 1])
+            lemma_vecs.append(
+                np.full((2, dim), fill_value=float(b + 1), dtype=np.float32)
+            )
+        lemma_vecs = np.stack(lemma_vecs, axis=0)
+        scores = np.zeros((batch_size, 2), dtype=np.float32)
+        return lemma_ids, lemma_vecs, scores
+
+
+class PremisePoolTests(unittest.TestCase):
+    def test_builds_unified_pool(self) -> None:
+        goal_vecs = torch.randn(2, 4)
+        node_embeddings = torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+                [1.0, 1.0, 0.0, 0.0],
+                [0.0, 1.0, 1.0, 0.0],
+            ],
+            dtype=torch.float,
+        )
+        premise_mask = torch.tensor([True, False, True, False, True, True])
+        batch_index = torch.tensor([0, 0, 0, 1, 1, 1], dtype=torch.long)
+
+        pools = build_unified_pools(
+            goal_vecs,
+            node_embeddings,
+            premise_mask,
+            batch_index,
+            lemma_index=_FakeLemmaIndex(),
+            k=2,
+        )
+
+        self.assertEqual(len(pools), 2)
+
+        pool0 = pools[0]
+        self.assertEqual(pool0.local_node_ids, [0, 2])
+        self.assertEqual(pool0.lemma_ids, [100, 101])
+        self.assertEqual(pool0.candidate_sources.count("local"), 2)
+        self.assertEqual(pool0.candidate_sources.count("lemma"), 2)
+        self.assertEqual(pool0.candidate_vectors.shape[0], 4)
+
+        pool1 = pools[1]
+        self.assertEqual(pool1.local_node_ids, [4, 5])
+        self.assertEqual(pool1.lemma_ids, [102, 103])
+        self.assertEqual(pool1.candidate_sources.count("local"), 2)
+        self.assertEqual(pool1.candidate_sources.count("lemma"), 2)
+        self.assertEqual(pool1.candidate_vectors.shape[0], 4)

--- a/tests/test_premise_scoring.py
+++ b/tests/test_premise_scoring.py
@@ -1,0 +1,275 @@
+"""Unit tests for the premise scoring head (Phase 5)."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import torch
+
+from atp_lean_gnn.premise_pool import CandidatePool
+from atp_lean_gnn.premise_scoring import (
+    PremiseScorer,
+    PremiseScorerConfig,
+    compute_premise_ranking_loss,
+    _find_target_index_in_pool,
+)
+
+
+def _make_pool(
+    *,
+    num_local: int = 2,
+    num_lemma: int = 3,
+    hidden_dim: int = 8,
+) -> CandidatePool:
+    """Create a synthetic CandidatePool for testing."""
+    local_vecs = torch.randn(num_local, hidden_dim)
+    lemma_vecs = torch.randn(num_lemma, hidden_dim)
+    candidate_vectors = torch.cat([local_vecs, lemma_vecs], dim=0)
+    candidate_sources = ["local"] * num_local + ["lemma"] * num_lemma
+    local_ids = list(range(num_local))
+    lemma_ids = [100 + i for i in range(num_lemma)]
+    candidate_ids = local_ids + lemma_ids
+    return CandidatePool(
+        candidate_vectors=candidate_vectors,
+        candidate_sources=candidate_sources,
+        candidate_ids=candidate_ids,
+        local_node_ids=local_ids,
+        lemma_ids=lemma_ids,
+    )
+
+
+class TestPremiseScorerConfig(unittest.TestCase):
+    def test_default_config(self) -> None:
+        config = PremiseScorerConfig()
+        self.assertEqual(config.hidden_dim, 128)
+        self.assertEqual(config.scoring_mode, "dot")
+        self.assertEqual(config.tactic_conditioning, "soft")
+        self.assertAlmostEqual(config.premise_loss_weight, 0.3)
+
+    def test_to_dict(self) -> None:
+        config = PremiseScorerConfig(hidden_dim=64, scoring_mode="mlp")
+        d = config.to_dict()
+        self.assertEqual(d["hidden_dim"], 64)
+        self.assertEqual(d["scoring_mode"], "mlp")
+
+
+class TestPremiseScorerDot(unittest.TestCase):
+    def setUp(self) -> None:
+        self.hidden_dim = 8
+        self.scorer = PremiseScorer(self.hidden_dim, mode="dot")
+
+    def test_score_shape(self) -> None:
+        goal = torch.randn(self.hidden_dim)
+        tactic = torch.randn(self.hidden_dim)
+        candidates = torch.randn(5, self.hidden_dim)
+        scores = self.scorer.score(goal, tactic, candidates)
+        self.assertEqual(scores.shape, (5,))
+
+    def test_score_batched_shape(self) -> None:
+        goal = torch.randn(1, self.hidden_dim)
+        tactic = torch.randn(1, self.hidden_dim)
+        candidates = torch.randn(10, self.hidden_dim)
+        scores = self.scorer.score(goal, tactic, candidates)
+        self.assertEqual(scores.shape, (10,))
+
+    def test_forward_with_pools(self) -> None:
+        batch_size = 3
+        pools = [_make_pool(hidden_dim=self.hidden_dim) for _ in range(batch_size)]
+        goal_vecs = torch.randn(batch_size, self.hidden_dim)
+        tactic_embs = torch.randn(batch_size, self.hidden_dim)
+
+        scores = self.scorer(goal_vecs, tactic_embs, pools)
+        self.assertEqual(len(scores), batch_size)
+        for i, s in enumerate(scores):
+            expected_len = len(pools[i].candidate_ids)
+            self.assertEqual(s.shape, (expected_len,))
+
+    def test_invalid_mode_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            PremiseScorer(8, mode="invalid")
+
+    def test_batch_size_mismatch_raises(self) -> None:
+        pools = [_make_pool(hidden_dim=self.hidden_dim)]
+        goal_vecs = torch.randn(2, self.hidden_dim)  # mismatch
+        tactic_embs = torch.randn(2, self.hidden_dim)
+        with self.assertRaises(ValueError):
+            self.scorer(goal_vecs, tactic_embs, pools)
+
+
+class TestPremiseScorerMLP(unittest.TestCase):
+    def setUp(self) -> None:
+        self.hidden_dim = 8
+        self.scorer = PremiseScorer(self.hidden_dim, mode="mlp")
+
+    def test_score_shape(self) -> None:
+        goal = torch.randn(self.hidden_dim)
+        tactic = torch.randn(self.hidden_dim)
+        candidates = torch.randn(7, self.hidden_dim)
+        scores = self.scorer.score(goal, tactic, candidates)
+        self.assertEqual(scores.shape, (7,))
+
+    def test_mlp_differs_from_dot(self) -> None:
+        """MLP and dot should generally produce different scores."""
+        dot_scorer = PremiseScorer(self.hidden_dim, mode="dot")
+        goal = torch.randn(self.hidden_dim)
+        tactic = torch.randn(self.hidden_dim)
+        candidates = torch.randn(5, self.hidden_dim)
+
+        dot_scores = dot_scorer.score(goal, tactic, candidates)
+        mlp_scores = self.scorer.score(goal, tactic, candidates)
+
+        # They should not be identical (different architectures)
+        self.assertFalse(torch.allclose(dot_scores, mlp_scores))
+
+
+class TestFindTargetIndex(unittest.TestCase):
+    def test_local_match(self) -> None:
+        pool = _make_pool(num_local=3, num_lemma=2, hidden_dim=4)
+        # local IDs are [0, 1, 2], want node 1
+        idx = _find_target_index_in_pool(
+            pool, arg_node_indices=[1], arg_lemma_ids=[-1]
+        )
+        self.assertEqual(idx, 1)
+
+    def test_lemma_match(self) -> None:
+        pool = _make_pool(num_local=2, num_lemma=3, hidden_dim=4)
+        # lemma IDs are [100, 101, 102], want lemma 101
+        idx = _find_target_index_in_pool(
+            pool, arg_node_indices=[-1], arg_lemma_ids=[101]
+        )
+        # Pool order: [local0, local1, lemma100, lemma101, lemma102]
+        self.assertEqual(idx, 3)
+
+    def test_no_match(self) -> None:
+        pool = _make_pool(num_local=2, num_lemma=2, hidden_dim=4)
+        idx = _find_target_index_in_pool(
+            pool, arg_node_indices=[-1], arg_lemma_ids=[-1]
+        )
+        self.assertEqual(idx, -1)
+
+    def test_local_preferred_over_lemma(self) -> None:
+        pool = _make_pool(num_local=2, num_lemma=2, hidden_dim=4)
+        # Both local and lemma match — local should win
+        idx = _find_target_index_in_pool(
+            pool, arg_node_indices=[0], arg_lemma_ids=[100]
+        )
+        self.assertEqual(idx, 0)  # local match at position 0
+
+
+class TestPremiseRankingLoss(unittest.TestCase):
+    def test_basic_loss_and_metrics(self) -> None:
+        hidden_dim = 8
+        pool = _make_pool(num_local=2, num_lemma=3, hidden_dim=hidden_dim)
+        # Simulate scores: highest score is at index 0
+        scores = torch.tensor([5.0, 1.0, 2.0, -1.0, 0.0], requires_grad=True)
+
+        # Target: local node 0 (pool position 0) -> Rank 1
+        arg_node_indices = torch.tensor([[0, -1]])
+        arg_lemma_ids = torch.tensor([[-1, -1]])
+
+        loss, metrics = compute_premise_ranking_loss(
+            [scores], [pool], arg_node_indices, arg_lemma_ids
+        )
+
+        self.assertTrue(loss.requires_grad)
+        self.assertEqual(metrics["valid_samples"], 1)
+        self.assertEqual(metrics["total_samples"], 1)
+        self.assertEqual(metrics["target_present_count"], 1)
+        self.assertEqual(metrics["top1_correct"], 1)
+        self.assertEqual(metrics["top5_correct"], 1)
+        self.assertAlmostEqual(metrics["mrr_sum"], 1.0)
+        self.assertGreater(loss.item(), 0.0)  # CE is always positive
+
+    def test_lower_rank_metrics(self) -> None:
+        hidden_dim = 8
+        pool = _make_pool(num_local=2, num_lemma=3, hidden_dim=hidden_dim)
+        # Simulate scores: target at index 1 gets the 3rd highest score
+        # Sorted scores will be: index 0 (5.0), index 2 (4.0), index 1 (3.0)...
+        scores = torch.tensor([5.0, 3.0, 4.0, -1.0, 0.0], requires_grad=True)
+
+        # Target: local node 1 (pool position 1) -> Rank 3
+        arg_node_indices = torch.tensor([[1, -1]])
+        arg_lemma_ids = torch.tensor([[-1, -1]])
+
+        loss, metrics = compute_premise_ranking_loss(
+            [scores], [pool], arg_node_indices, arg_lemma_ids
+        )
+
+        self.assertEqual(metrics["top1_correct"], 0)
+        self.assertEqual(metrics["top5_correct"], 1)
+        self.assertAlmostEqual(metrics["mrr_sum"], 1.0 / 3.0)
+
+    def test_no_target_present(self) -> None:
+        hidden_dim = 8
+        pool = _make_pool(num_local=2, num_lemma=3, hidden_dim=hidden_dim)
+        scores = torch.randn(5, requires_grad=True)
+
+        # No valid targets at all
+        arg_node_indices = torch.tensor([[-1, -1]])
+        arg_lemma_ids = torch.tensor([[-1, -1]])
+
+        loss, metrics = compute_premise_ranking_loss(
+            [scores], [pool], arg_node_indices, arg_lemma_ids
+        )
+
+        self.assertEqual(metrics["target_present_count"], 0)
+        self.assertEqual(metrics["valid_samples"], 0)
+        self.assertAlmostEqual(loss.item(), 0.0)
+
+    def test_target_present_but_not_retrieved(self) -> None:
+        hidden_dim = 8
+        pool = _make_pool(num_local=2, num_lemma=3, hidden_dim=hidden_dim)
+        scores = torch.randn(5, requires_grad=True)
+
+        # Target is a lemma that isn't in the pool
+        arg_node_indices = torch.tensor([[-1, -1]])
+        arg_lemma_ids = torch.tensor([[999, -1]])
+
+        loss, metrics = compute_premise_ranking_loss(
+            [scores], [pool], arg_node_indices, arg_lemma_ids
+        )
+
+        self.assertEqual(metrics["target_present_count"], 1)
+        self.assertEqual(metrics["valid_samples"], 0)
+        self.assertEqual(metrics["mrr_sum"], 0.0)
+        self.assertAlmostEqual(loss.item(), 0.0)
+
+    def test_batch_loss(self) -> None:
+        hidden_dim = 8
+        pools = [_make_pool(num_local=2, num_lemma=3, hidden_dim=hidden_dim) for _ in range(3)]
+        scores = [torch.randn(5) for _ in range(3)]
+
+        # Sample 0: valid target, retrieved.
+        # Sample 1: no target.
+        # Sample 2: valid target, retrieved.
+        arg_node_indices = torch.tensor([[0, -1], [-1, -1], [1, -1]])
+        arg_lemma_ids = torch.tensor([[-1, -1], [-1, -1], [-1, -1]])
+
+        loss, metrics = compute_premise_ranking_loss(
+            scores, pools, arg_node_indices, arg_lemma_ids
+        )
+
+        self.assertEqual(metrics["target_present_count"], 2)
+        self.assertEqual(metrics["valid_samples"], 2)
+        self.assertEqual(metrics["total_samples"], 3)
+
+    def test_tactic_conditioning_changes_output(self) -> None:
+        """Changing the tactic embedding should change the scores."""
+        hidden_dim = 8
+        scorer = PremiseScorer(hidden_dim, mode="dot")
+        goal = torch.randn(1, hidden_dim)
+        pool = _make_pool(num_local=2, num_lemma=3, hidden_dim=hidden_dim)
+
+        tactic1 = torch.randn(1, hidden_dim)
+        tactic2 = torch.randn(1, hidden_dim)
+
+        scores1 = scorer(goal, tactic1, [pool])
+        scores2 = scorer(goal, tactic2, [pool])
+
+        # Different tactic embeddings should produce different scores
+        self.assertFalse(torch.allclose(scores1[0], scores2[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces the Library Premise Selection & Scorer architecture to the ATP Lean GNN repository. It implements external library premise retrieval (via FAISS similarity search) combined with local context premise ranking, resolving the issue where argument selection was restricted solely to the local proof state.

**Architectural Overview**

At inference time, when a Lean proof state (e.g. n : Nat ⊢ n + 0 = n) is parsed, the pipeline performs:

- Graph Encoding: Computes node embeddings and aggregates them into a state representation vector (state_emb).
- Library Retrieval (FAISS): Uses state_emb to query a FAISS similarity search index of Mathlib lemmas, retrieving the top K relevant premises.
- Unified Candidate Pool: Merges the retrieved library lemmas and the local nodes (hypotheses) into a single candidate pool.
- Scoring & Ranking: The PremiseScorer uses dot-product or MLP scoring to rank all pool candidates. The highest-ranked candidate is decoded back to text to construct the final predicted tactic.
- Added a new test file: tests/test_lemma_index.py to cover FAISS boundary scenarios.